### PR TITLE
fix: add netlify.toml to fix Netlify deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Problem
Netlify deploys were failing because there was no `netlify.toml` config file. Without it, Netlify uses an outdated default Node.js version incompatible with the current dependencies, and there are no SPA redirect rules so direct URL access returns 404.

## Changes
Added `netlify.toml` with:
- **Node 20** build environment (matches local dev)
- **`npm run build`** as the build command with `dist` as the publish directory
- **SPA redirect rule** (`/* → /index.html`) so React Router hash-based navigation works correctly on all URLs