### PR TITLE
fix: replace ts-node with tsx in api export:spec to fix ESM compatibility

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qautils-api",
   "version": "1.4.3",
-  "description": "REST API for QA Utils \u2014 powers Swagger UI for automation test consumption",
+  "description": "REST API for QA Utils — powers Swagger UI for automation test consumption",
   "license": "MIT",
   "type": "commonjs",
   "main": "dist/api/src/index.js",
@@ -12,7 +12,7 @@
     "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run",
     "test:watch": "vitest",
-    "export:spec": "ts-node src/export-spec.ts"
+    "export:spec": "tsx src/export-spec.ts"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -38,6 +38,7 @@
     "supertest": "^7.0.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
   }


### PR DESCRIPTION
## Problem

The last 3 GitHub Pages deployments (runs #138, #139, #140) have been failing, preventing the new UI/UX changes from PRs #89 and #92 from appearing on the live site.

**Root cause:** PR #90 ("Consolidate all tool implementations into a single source of truth") made `api/src/tools.ts` import from `../../src/utils/sharedToolsNode.ts`. Since the root `package.json` has `"type": "module"`, all `.ts` files in the root are treated as ESM. However, the API uses `ts-node` (CJS-based) for its `export:spec` script, which cannot `require()` ESM files — causing it to crash with `ERR_REQUIRE_ESM`.

This breaks the `build:api-docs` step in the deployment workflow, which calls `npm run export:spec`.

## Fix

Replaced `ts-node` with `tsx` in the `export:spec` script. `tsx` handles ESM/CJS interop seamlessly, resolving the import failure.

## Changes

- `api/package.json`: Changed `export:spec` script from `ts-node` to `tsx`, added `tsx` as a dev dependency

## Verification

- ✅ `npm run export:spec` succeeds
- ✅ `npm run build:api-docs` succeeds  
- ✅ `npm run build:github` succeeds
- ✅ `npm run docs:build` succeeds