### PR TITLE
fix: update the dev script in package.json file

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "main": "dist/api/src/index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "tsx watch src/index.ts",
     "start": "node dist/api/src/index.js",
     "build": "tsc",
     "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
The root cause: the root `package.json`  has `"type": "module"`, making `sharedToolsNode.ts` an ES Module. When ts-node-dev (which runs in CommonJS mode) tries to require() it, Node.js rejects it with "Must use import to load ES Module."

Fix: Replaced ts-node-dev with tsx watch in the API's dev script. tsx uses a modern loader that handles both ESM and CJS transparently — it doesn't have the interop limitation that ts-node-dev hits when crossing module-type boundaries. tsx was already installed in the API's devDependencies and is already used for the export:spec script.

Results:
<img width="464" height="140" alt="Screenshot 2026-05-01 at 10 21 46 PM" src="https://github.com/user-attachments/assets/96853ca4-d4d5-4801-b46e-baa7306df25e" />