### PR TITLE
feat: add File Comparator tool — compare files with multi-format support

### DIFF
--- a/api/src/__tests__/analysers.test.ts
+++ b/api/src/__tests__/analysers.test.ts
@@ -105,3 +105,50 @@ describe('POST /api/analysers/regex', () => {
     expect(res.status).toBe(400);
   });
 });
+
+// ── compare ──────────────────────────────────────────────────────────────────
+
+describe('POST /api/analysers/compare', () => {
+  it('returns 100% similarity for identical texts', async () => {
+    const res = await post('/api/analysers/compare', {
+      text1: 'line 1\nline 2',
+      text2: 'line 1\nline 2',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.similarity).toBe(100);
+    expect(res.body.stats.sameLines).toBe(2);
+    expect(res.body.stats.addedLines).toBe(0);
+    expect(res.body.stats.removedLines).toBe(0);
+  });
+
+  it('detects differences between texts', async () => {
+    const res = await post('/api/analysers/compare', {
+      text1: 'hello\nworld',
+      text2: 'hello\nearth',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.stats.sameLines).toBe(1);
+    expect(res.body.diffLines).toBeInstanceOf(Array);
+    expect(res.body.diffLines.length).toBeGreaterThan(0);
+  });
+
+  it('respects ignoreCase option', async () => {
+    const res = await post('/api/analysers/compare', {
+      text1: 'Hello',
+      text2: 'hello',
+      ignoreCase: true,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.similarity).toBe(100);
+  });
+
+  it('respects ignoreWhitespace option', async () => {
+    const res = await post('/api/analysers/compare', {
+      text1: 'hello   world',
+      text2: 'hello world',
+      ignoreWhitespace: true,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.similarity).toBe(100);
+  });
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -40,7 +40,7 @@ const swaggerOptions: swaggerJsdoc.Options = {
     tags: [
       { name: 'Generators', description: 'Generate UUIDs, passwords, NanoIDs, lorem ipsum, random strings' },
       { name: 'Converters', description: 'Base64, URL, hash, color, timestamp, base and case converters' },
-      { name: 'Analysers', description: 'Text stats, email validation, JWT decoding, regex testing' },
+      { name: 'Analysers', description: 'Text stats, email validation, JWT decoding, regex testing, text comparison' },
       { name: 'Formatters', description: 'JSON formatting, HTML sanitization, SQL generation' },
       { name: 'Agents', description: 'Autonomous AI agent — run multi-step tasks with built-in tools' },
       { name: 'GraphQL', description: 'Proxy GraphQL queries, mutations and introspection to any endpoint' },

--- a/api/src/routes/analysers.ts
+++ b/api/src/routes/analysers.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { countTextStats, validateEmail, decodeJwt, testRegex } from '../tools';
-import { TextStatsSchema, EmailValidateSchema, JwtDecodeSchema, RegexSchema } from '../schemas';
+import { countTextStats, validateEmail, decodeJwt, testRegex, compareTexts } from '../tools';
+import { TextStatsSchema, EmailValidateSchema, JwtDecodeSchema, RegexSchema, TextCompareSchema } from '../schemas';
 
 export const analysersRouter = Router();
 
@@ -216,4 +216,110 @@ analysersRouter.post('/regex', (req, res) => {
   }
   const { pattern, text, flags } = parsed.data;
   res.json(testRegex(pattern, flags, text));
+});
+
+/**
+ * @openapi
+ * /api/analysers/compare:
+ *   post:
+ *     tags: [Analysers]
+ *     summary: Compare two text inputs and produce a line-by-line diff with similarity scoring
+ *     description: |
+ *       Accepts two plain-text strings and returns a structured diff with
+ *       same / added / removed / modified classification for every line.
+ *       Uses an LCS (Longest Common Subsequence) algorithm for optimal alignment
+ *       and Levenshtein distance for similarity scoring on near-matches.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [text1, text2]
+ *             properties:
+ *               text1:
+ *                 type: string
+ *                 description: First text to compare
+ *                 example: "line 1\nline 2\nline 3"
+ *               text2:
+ *                 type: string
+ *                 description: Second text to compare
+ *                 example: "line 1\nline 2 modified\nline 4"
+ *               ignoreWhitespace:
+ *                 type: boolean
+ *                 default: false
+ *                 description: Collapse whitespace before comparing
+ *               ignoreCase:
+ *                 type: boolean
+ *                 default: false
+ *                 description: Case-insensitive comparison
+ *               ignoreBlankLines:
+ *                 type: boolean
+ *                 default: false
+ *                 description: Skip blank lines
+ *               similarityThreshold:
+ *                 type: number
+ *                 minimum: 0
+ *                 maximum: 1
+ *                 default: 0.6
+ *                 description: Minimum similarity ratio (0–1) to classify a removed+added pair as "modified" instead of separate entries
+ *     responses:
+ *       200:
+ *         description: Comparison result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 similarity:
+ *                   type: integer
+ *                   description: Overall similarity percentage (0–100)
+ *                 stats:
+ *                   type: object
+ *                   properties:
+ *                     totalLines:
+ *                       type: integer
+ *                     sameLines:
+ *                       type: integer
+ *                     addedLines:
+ *                       type: integer
+ *                     removedLines:
+ *                       type: integer
+ *                     modifiedLines:
+ *                       type: integer
+ *                     similarityPercentage:
+ *                       type: integer
+ *                 diffLines:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       type:
+ *                         type: string
+ *                         enum: [same, added, removed, modified]
+ *                       lineNumber1:
+ *                         type: integer
+ *                         nullable: true
+ *                       lineNumber2:
+ *                         type: integer
+ *                         nullable: true
+ *                       content:
+ *                         type: string
+ *                       oldContent:
+ *                         type: string
+ *                         nullable: true
+ *                       similarity:
+ *                         type: integer
+ *                         nullable: true
+ *       400:
+ *         $ref: '#/components/responses/ValidationError'
+ */
+analysersRouter.post('/compare', (req, res) => {
+  const parsed = TextCompareSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Validation failed', details: parsed.error.flatten() });
+    return;
+  }
+  const { text1, text2, ignoreWhitespace, ignoreCase, ignoreBlankLines, similarityThreshold } = parsed.data;
+  res.json(compareTexts(text1, text2, { ignoreWhitespace, ignoreCase, ignoreBlankLines, similarityThreshold }));
 });

--- a/api/src/schemas.ts
+++ b/api/src/schemas.ts
@@ -110,6 +110,17 @@ export const MarkdownToConfluenceSchema = z.object({
   markdown: z.string().min(1, 'markdown is required'),
 });
 
+// ── Text Comparison ──────────────────────────────────────────────────────
+
+export const TextCompareSchema = z.object({
+  text1: z.string().min(0, 'text1 is required'),
+  text2: z.string().min(0, 'text2 is required'),
+  ignoreWhitespace: z.coerce.boolean().default(false),
+  ignoreCase: z.coerce.boolean().default(false),
+  ignoreBlankLines: z.coerce.boolean().default(false),
+  similarityThreshold: z.coerce.number().min(0).max(1).default(0.6),
+});
+
 // ── Data ──────────────────────────────────────────────────────────────────────
 
 export const SqlGenerateSchema = z.object({

--- a/api/src/tools.ts
+++ b/api/src/tools.ts
@@ -55,6 +55,8 @@ export {
   CASE_TYPES,
   // Markdown
   convertMarkdownToConfluence,
+  // Text Comparison
+  compareTexts,
 } from '../../src/utils/sharedToolsNode';
 
 export type {
@@ -75,4 +77,7 @@ export type {
   RegexTestResult,
   BaseConversionResult,
   CaseType,
+  // Text Comparison
+  TextComparisonOptions,
+  TextComparisonResult,
 } from '../../src/utils/sharedToolsNode';

--- a/cli/src/__tests__/compare.test.ts
+++ b/cli/src/__tests__/compare.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { compareTexts } from '../lib/tools.js';
+
+describe('compareTexts', () => {
+  it('returns 100% similarity for identical texts', () => {
+    const result = compareTexts('line 1\nline 2\nline 3', 'line 1\nline 2\nline 3');
+    expect(result.similarity).toBe(100);
+    expect(result.stats.sameLines).toBe(3);
+    expect(result.stats.addedLines).toBe(0);
+    expect(result.stats.removedLines).toBe(0);
+    expect(result.stats.modifiedLines).toBe(0);
+  });
+
+  it('detects added lines', () => {
+    const result = compareTexts('a\nb', 'a\nb\nc');
+    expect(result.stats.addedLines).toBe(1);
+    const added = result.diffLines.find(d => d.type === 'added');
+    expect(added).toBeDefined();
+    expect(added?.content).toBe('c');
+  });
+
+  it('detects removed lines', () => {
+    const result = compareTexts('a\nb\nc', 'a\nb');
+    expect(result.stats.removedLines).toBe(1);
+    const removed = result.diffLines.find(d => d.type === 'removed');
+    expect(removed).toBeDefined();
+    expect(removed?.content).toBe('c');
+  });
+
+  it('detects modified lines with similarity', () => {
+    const result = compareTexts('hello world', 'hello world!');
+    const modified = result.diffLines.find(d => d.type === 'modified');
+    expect(modified).toBeDefined();
+    expect(modified?.similarity).toBeGreaterThan(0);
+    expect(modified?.oldContent).toBe('hello world');
+    expect(modified?.content).toBe('hello world!');
+  });
+
+  it('returns 0% similarity for completely different texts', () => {
+    const result = compareTexts('aaa\nbbb\nccc', 'xxx\nyyy\nzzz');
+    expect(result.similarity).toBeLessThan(50);
+    expect(result.stats.sameLines).toBe(0);
+  });
+
+  it('respects ignoreCase option', () => {
+    const result = compareTexts('Hello', 'hello', { ignoreCase: true });
+    expect(result.stats.sameLines).toBe(1);
+    expect(result.similarity).toBe(100);
+  });
+
+  it('respects ignoreWhitespace option', () => {
+    const result = compareTexts('hello   world', 'hello world', { ignoreWhitespace: true });
+    expect(result.stats.sameLines).toBe(1);
+    expect(result.similarity).toBe(100);
+  });
+
+  it('respects ignoreBlankLines option', () => {
+    const result = compareTexts('a\n\nb', 'a\nb', { ignoreBlankLines: true });
+    expect(result.stats.sameLines).toBe(2);
+    expect(result.similarity).toBe(100);
+  });
+
+  it('handles empty inputs', () => {
+    const result = compareTexts('', '');
+    expect(result.similarity).toBe(100);
+    expect(result.stats.totalLines).toBe(1); // one empty line
+  });
+
+  it('returns structured stats', () => {
+    const result = compareTexts('a\nb', 'a\nc');
+    expect(result.stats).toHaveProperty('totalLines');
+    expect(result.stats).toHaveProperty('sameLines');
+    expect(result.stats).toHaveProperty('addedLines');
+    expect(result.stats).toHaveProperty('removedLines');
+    expect(result.stats).toHaveProperty('modifiedLines');
+    expect(result.stats).toHaveProperty('similarityPercentage');
+  });
+});

--- a/cli/src/commands/compare.ts
+++ b/cli/src/commands/compare.ts
@@ -1,0 +1,102 @@
+import type { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import chalk from 'chalk';
+import { compareTexts, type TextComparisonResult, type TextDiffLine } from '../lib/tools.js';
+import { printError, printHeading, printRow, printTable, printDivider, printJson } from '../utils/output.js';
+
+const DIFF_SYMBOLS: Record<TextDiffLine['type'], { symbol: string; color: (s: string) => string }> = {
+  same:     { symbol: ' ', color: (s) => s },
+  added:    { symbol: '+', color: chalk.green },
+  removed:  { symbol: '-', color: chalk.red },
+  modified: { symbol: '~', color: chalk.yellow },
+};
+
+function printDiff(result: TextComparisonResult, file1: string, file2: string, format: string): void {
+  if (format === 'json') {
+    printJson({ file1, file2, ...result });
+    return;
+  }
+
+  // Stats header
+  printHeading('File Comparison');
+  printRow('File 1', file1);
+  printRow('File 2', file2);
+  printDivider();
+  const simColor = result.similarity >= 80 ? chalk.green : result.similarity >= 50 ? chalk.yellow : chalk.red;
+  printRow('Similarity', simColor(`${result.similarity}%`));
+  printTable([
+    ['Same',     chalk.white(String(result.stats.sameLines))],
+    ['Added',    chalk.green(String(result.stats.addedLines))],
+    ['Removed',  chalk.red(String(result.stats.removedLines))],
+    ['Modified', chalk.yellow(String(result.stats.modifiedLines))],
+    ['Total',    chalk.white(String(result.stats.totalLines))],
+  ]);
+
+  if (format === 'stats') return;
+
+  // Unified diff output
+  console.log();
+  console.log(chalk.cyan(`--- ${file1}`));
+  console.log(chalk.cyan(`+++ ${file2}`));
+  console.log();
+
+  for (const line of result.diffLines) {
+    const { symbol, color } = DIFF_SYMBOLS[line.type];
+    if (line.type === 'modified') {
+      console.log(chalk.red(`- ${line.oldContent}`));
+      console.log(chalk.green(`+ ${line.content}`));
+    } else {
+      console.log(color(`${symbol} ${line.content}`));
+    }
+  }
+}
+
+export function registerCompareCommand(program: Command): void {
+  program
+    .command('compare <file1> <file2>')
+    .description('Compare two text files and show a line-by-line diff with similarity scoring')
+    .option('-w, --ignore-whitespace', 'ignore whitespace differences', false)
+    .option('-i, --ignore-case', 'ignore case differences', false)
+    .option('-b, --ignore-blank-lines', 'ignore blank lines', false)
+    .option('-t, --threshold <number>', 'similarity threshold (0-100) for "modified" detection', '60')
+    .option('-f, --format <format>', 'output format: diff, stats, json', 'diff')
+    .action((file1: string, file2: string, options: {
+      ignoreWhitespace: boolean;
+      ignoreCase: boolean;
+      ignoreBlankLines: boolean;
+      threshold: string;
+      format: string;
+    }) => {
+      let text1: string;
+      let text2: string;
+
+      try {
+        text1 = readFileSync(file1, 'utf-8');
+      } catch {
+        printError(`Cannot read file: ${file1}`);
+        process.exit(1);
+      }
+
+      try {
+        text2 = readFileSync(file2, 'utf-8');
+      } catch {
+        printError(`Cannot read file: ${file2}`);
+        process.exit(1);
+      }
+
+      const threshold = parseInt(options.threshold, 10);
+      if (isNaN(threshold) || threshold < 0 || threshold > 100) {
+        printError('Threshold must be a number between 0 and 100');
+        process.exit(1);
+      }
+
+      const result = compareTexts(text1, text2, {
+        ignoreWhitespace: options.ignoreWhitespace,
+        ignoreCase: options.ignoreCase,
+        ignoreBlankLines: options.ignoreBlankLines,
+        similarityThreshold: threshold / 100,
+      });
+
+      printDiff(result, file1, file2, options.format);
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,7 +16,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 
 import { version as CLI_VERSION } from './version.js';
-import { runInteractive, printBanner } from './interactive.js';
+import { runInteractive, printBanner, TOOL_COUNT } from './interactive.js';
 
 import { registerUuidCommand }      from './commands/uuid.js';
 import { registerBase64Command }    from './commands/base64.js';
@@ -43,7 +43,9 @@ import { registerChatCommand }        from './commands/chat.js';
 import { registerAgentCommand }       from './commands/agent.js';
 import { registerOrchestrateCommand } from './commands/orchestrate.js';
 import { registerMarkdownCommand }    from './commands/markdown.js';
-import { registerPromptCommand }      from './commands/prompt.js';import { registerGraphqlCommand }     from './commands/graphql.js';
+import { registerPromptCommand }      from './commands/prompt.js';
+import { registerGraphqlCommand }     from './commands/graphql.js';
+import { registerCompareCommand }     from './commands/compare.js';
 // ── Program ──────────────────────────────────────────────────────────────────
 
 const program = new Command();
@@ -52,7 +54,7 @@ program
   .name('qautils')
   .description(
     chalk.bold('QA Utils CLI') +
-      chalk.dim(' — 21 utility tools for testing and automation workflows') +
+      chalk.dim(' — 24 utility tools for testing and automation workflows') +
       '\n' +
       chalk.dim('  https://github.com/kobenguyent/qa-utils'),
   )
@@ -101,6 +103,13 @@ ${chalk.bold('Data Toolkit')}:
   ${chalk.cyan('qautils sql SELECT --table users')}       Generate SELECT SQL
   ${chalk.cyan('qautils html sanitize "<p>…</p>"')}      Sanitize HTML
   ${chalk.cyan('qautils md-confluence "# Hello\\n**bold**"')} Convert Markdown to Confluence Wiki
+
+${chalk.bold('File Comparison')}:
+  ${chalk.cyan('qautils compare file1.txt file2.txt')}     Compare two text files
+  ${chalk.cyan('qautils compare a.txt b.txt -w -i')}       Ignore whitespace and case
+  ${chalk.cyan('qautils compare a.txt b.txt -f stats')}    Summary stats only
+  ${chalk.cyan('qautils compare a.txt b.txt -f json')}     JSON output
+  ${chalk.cyan('qautils compare a.txt b.txt -t 80')}       Custom similarity threshold
 
 ${chalk.bold('GraphQL')}:
   ${chalk.cyan('qautils graphql query <endpoint> <query>')}  Execute a GraphQL query
@@ -172,6 +181,8 @@ registerMarkdownCommand(program);
 registerPromptCommand(program);
 // GraphQL client
 registerGraphqlCommand(program);
+// File comparison
+registerCompareCommand(program);
 
 // ── Launch mode ───────────────────────────────────────────────────────────────
 
@@ -190,6 +201,6 @@ if (isInteractive) {
   });
 } else {
   // Direct CLI mode: parse and dispatch
-  printBanner();
+  printBanner(TOOL_COUNT);
   program.parse(process.argv);
 }

--- a/cli/src/interactive.ts
+++ b/cli/src/interactive.ts
@@ -18,6 +18,7 @@ import {
   convertCase, generateNanoId, HASH_ALGORITHMS, CASE_TYPES,
   convertMarkdownToConfluence,
   buildJsonPrompt, parseJsonPrompt, extractTemplateVariables,
+  compareTexts,
   type HashAlgorithm, type SqlOperation, type CaseType,
   type PromptProviderFormat, type JsonPromptTemplate,
 } from './lib/tools.js';
@@ -813,12 +814,65 @@ async function runMarkdownToConfluence(): Promise<string | null> {
   return result;
 }
 
+// ── File Comparator ───────────────────────────────────────────────────────────
+async function runCompare(): Promise<string | null> {
+  const text1 = await input({ message: 'Paste text 1 (first file content):' });
+  if (!text1.trim()) { console.log(T.dim('\n  No input provided.\n')); return null; }
+  const text2 = await input({ message: 'Paste text 2 (second file content):' });
+  if (!text2.trim()) { console.log(T.dim('\n  No input provided.\n')); return null; }
+
+  const ignoreWs = await select<boolean>({
+    message: 'Ignore whitespace?',
+    choices: [{ name: 'No', value: false }, { name: 'Yes', value: true }],
+  });
+  const ignoreCase = await select<boolean>({
+    message: 'Ignore case?',
+    choices: [{ name: 'No', value: false }, { name: 'Yes', value: true }],
+  });
+
+  const sp = spin('Comparing…').start();
+  const result = compareTexts(text1, text2, {
+    ignoreWhitespace: ignoreWs,
+    ignoreCase,
+    similarityThreshold: 0.6,
+  });
+  sp.stop();
+
+  const simColor = result.similarity >= 80 ? T.success : result.similarity >= 50 ? T.warn : T.error;
+  resultBox('File Comparison', [
+    `${T.label('Similarity'.padEnd(14))} ${simColor(`${result.similarity}%`)}`,
+    `${T.label('Same'.padEnd(14))} ${T.value(String(result.stats.sameLines))}`,
+    `${T.label('Added'.padEnd(14))} ${chalk.green(String(result.stats.addedLines))}`,
+    `${T.label('Removed'.padEnd(14))} ${chalk.red(String(result.stats.removedLines))}`,
+    `${T.label('Modified'.padEnd(14))} ${chalk.yellow(String(result.stats.modifiedLines))}`,
+    `${T.label('Total'.padEnd(14))} ${T.value(String(result.stats.totalLines))}`,
+  ]);
+
+  // Show first 30 diff lines
+  const preview = result.diffLines.slice(0, 30);
+  for (const line of preview) {
+    if (line.type === 'same')    console.log(chalk.gray(`    ${line.content}`));
+    if (line.type === 'added')   console.log(chalk.green(`  + ${line.content}`));
+    if (line.type === 'removed') console.log(chalk.red(`  - ${line.content}`));
+    if (line.type === 'modified') {
+      console.log(chalk.red(`  - ${line.oldContent}`));
+      console.log(chalk.green(`  + ${line.content}`));
+    }
+  }
+  if (result.diffLines.length > 30) {
+    console.log(T.dim(`\n  … and ${result.diffLines.length - 30} more lines`));
+  }
+  console.log();
+  cliTip('compare file1.txt file2.txt');
+  return JSON.stringify(result.stats);
+}
+
 // ── Tool registry ─────────────────────────────────────────────────────────────
 type ToolKey =
   | 'uuid' | 'base64' | 'jwt' | 'hash' | 'password' | 'timestamp'
   | 'json' | 'lorem' | 'text' | 'email' | 'sql' | 'color' | 'html'
   | 'random' | 'url' | 'regex' | 'base' | 'case' | 'nanoid' | 'chat'
-  | 'orchestrate' | 'mdconfluence' | 'jsonprompt';
+  | 'orchestrate' | 'mdconfluence' | 'jsonprompt' | 'compare';
 
 const TOOLS: Record<ToolKey, { label: string; run: () => Promise<string | null> }> = {
   uuid:         { label: 'UUID Generator',            run: runUuid                },
@@ -844,9 +898,10 @@ const TOOLS: Record<ToolKey, { label: string; run: () => Promise<string | null> 
   jsonprompt:   { label: 'JSON Prompt Builder',         run: runJsonPromptBuilder   },
   chat:         { label: 'Kobean AI Chat',             run: runChat                },
   orchestrate:  { label: 'AI Orchestrator',            run: runOrchestrate         },
+  compare:      { label: 'File Comparator',             run: runCompare             },
 };
 
-const TOOL_COUNT = Object.keys(TOOLS).length;
+export const TOOL_COUNT = Object.keys(TOOLS).length;
 
 // ── Session history ───────────────────────────────────────────────────────────
 const sessionHistory: ToolKey[] = [];
@@ -894,6 +949,8 @@ async function showMainMenu(): Promise<ToolKey | 'exit'> {
   choices.push(item('🌐', 'HTML Sanitizer',            'html',         'Strip <script> tags and inline event handlers'));
   choices.push(item('📝', 'MD → Confluence Wiki',      'mdconfluence', 'Convert Markdown to Confluence Wiki markup'));
   choices.push(item('🧩', 'JSON Prompt Builder',       'jsonprompt',   'Build structured AI prompts (OpenAI, Anthropic, Gemini, generic)'));
+  choices.push(new Separator(T.dim('  ── Analysers ───────────────────────────────────── ')));
+  choices.push(item('🔍', 'File Comparator',            'compare',      'Compare two texts — same, similar, different lines'));
   choices.push(new Separator(T.dim('  ── AI ─────────────────────────────────────────── ')));
   choices.push(item('🤖', 'Kobean AI Chat',       'chat',        'Interactive AI chat (OpenAI, Anthropic, Gemini, Ollama…)'));
   choices.push(item('🧩', 'AI Orchestrator',      'orchestrate', 'Multi-agent pipeline — describe a task and let the AI team handle it'));

--- a/cli/src/lib/tools.ts
+++ b/cli/src/lib/tools.ts
@@ -61,6 +61,8 @@ export {
   validatePromptTemplate,
   buildJsonPrompt,
   parseJsonPrompt,
+  // Text Comparison
+  compareTexts,
 } from '../../../src/utils/sharedToolsNode.js';
 
 // GraphQL
@@ -108,4 +110,9 @@ export type {
   BuildJsonPromptResult,
   ParseJsonPromptResult,
   ValidatePromptResult,
+  // Text Comparison
+  TextComparisonOptions,
+  TextDiffLine,
+  TextComparisonStats,
+  TextComparisonResult,
 } from '../../../src/utils/sharedToolsNode.js';

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -10,10 +10,10 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
 // Resolve package.json relative to this compiled file's directory.
-// Compiled output: dist/src/version.js → package.json is at ../../package.json
+// Compiled output: dist/cli/src/version.js → package.json is at ../../../package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(
-  readFileSync(join(__dirname, '../../package.json'), 'utf-8'),
+  readFileSync(join(__dirname, '../../../package.json'), 'utf-8'),
 ) as { version: string };
 
 export { version };

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "rootDir": "..",
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,39 @@
+# Feature Implementation Plans
+
+> Production-ready technical specifications for new QA Utils features.
+
+Each document in this directory represents a **complete implementation blueprint** for a single tool/feature. Plans are designed to be self-contained — any engineer should be able to pick one up and deliver the feature end-to-end.
+
+---
+
+## Document Structure
+
+Every plan follows this standard structure:
+
+| Section | Purpose |
+|---------|---------|
+| **Overview** | What the feature does, who it's for, and why it matters |
+| **Technical Architecture** | System design, data flow, interfaces |
+| **Implementation Phases** | Ordered steps with clear deliverables |
+| **File Manifest** | Exact files to create/modify |
+| **Dependencies** | New packages, APIs, or services required |
+| **Testing Strategy** | Unit, integration, and manual test plans |
+| **Acceptance Criteria** | Definition of done |
+| **Rollback Plan** | How to safely revert if needed |
+
+---
+
+## Plans Index
+
+| # | Feature | Status | Document |
+|---|---------|--------|----------|
+| 1 | File Comparator | ✅ Complete | [file-comparator.md](./file-comparator.md) |
+
+---
+
+## Conventions
+
+- **One file per feature** — keeps scope manageable and reviewable
+- **Status labels**: 📋 Planned → 🚧 In Progress → ✅ Complete → 🗃️ Archived
+- **Naming**: lowercase kebab-case matching the route path (e.g., `file-comparator.md`)
+- **Phase numbering**: sequential, each phase is independently shippable where possible

--- a/docs/plans/file-comparator.md
+++ b/docs/plans/file-comparator.md
@@ -1,0 +1,538 @@
+# File Comparator — Implementation Plan
+
+> **Status**: ✅ Complete  
+> **Route**: `#/file-comparator`  
+> **Category**: Tools  
+> **Priority**: High  
+> **Estimated effort**: ~3–4 days  
+
+---
+
+## 1. Overview
+
+### 1.1 Problem Statement
+
+QA engineers and developers frequently need to compare two versions of a file — configuration diffs, exported reports, translated documents, migrated data. Existing tools (e.g., `diff`, Beyond Compare) are external desktop applications that don't integrate with the QA Utils workflow or support structured file formats natively.
+
+### 1.2 Solution
+
+A browser-based file comparison tool that:
+
+- Accepts **two files** of the same or different formats
+- Extracts text content from structured formats (PDF, DOCX, XLSX, CSV)
+- Produces a **line-by-line diff** with three classification levels:
+  - **Same** — identical lines
+  - **Similar** — lines with minor changes (threshold-configurable)
+  - **Different** — added or removed lines
+- Displays results in **side-by-side** or **unified** view
+- Computes an overall **similarity percentage**
+- Runs entirely in the browser — no server needed
+
+### 1.3 Supported Formats
+
+| Format | Extension(s) | Parser |
+|--------|-------------|--------|
+| Plain text | `.txt`, `.log`, `.md`, `.html`, `.xml`, `.yaml`, `.yml` | `FileReader.readAsText()` |
+| JSON | `.json` | `FileReader.readAsText()` + `JSON.stringify` (pretty) |
+| CSV / TSV | `.csv`, `.tsv` | Custom parser (RFC 4180 compliant) |
+| PDF | `.pdf` | `pdfjs-dist` (existing dependency) |
+| Word Document | `.docx` | `mammoth` (new dependency) |
+| Excel Spreadsheet | `.xlsx`, `.xls` | `xlsx` / SheetJS (new dependency) |
+
+### 1.4 Target Users
+
+- QA engineers validating data migration outputs
+- Developers comparing configuration files across environments
+- Technical writers reviewing document revisions
+- Anyone needing quick structural diff without installing desktop tools
+
+---
+
+## 2. Technical Architecture
+
+### 2.1 System Design
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    FileComparator.tsx                     │
+│  (UI: upload, options, results display)                  │
+├─────────────────────────────────────────────────────────┤
+│                    fileComparator.ts                      │
+│  (Core logic: extraction, diffing, scoring)              │
+├──────────────┬──────────────┬───────────────────────────┤
+│ PDF Parser   │ DOCX Parser  │ XLSX Parser │ Text Parser │
+│ (pdfjs-dist) │ (mammoth)    │ (xlsx)      │ (native)    │
+└──────────────┴──────────────┴─────────────┴─────────────┘
+```
+
+### 2.2 Data Flow
+
+```
+File A ──► extractText(file) ──► string[] (lines)
+                                        │
+                                        ▼
+                                  computeDiff(linesA, linesB)
+                                        │
+                                        ▼
+File B ──► extractText(file) ──► string[] (lines)
+                                        │
+                                        ▼
+                              ComparisonResult {
+                                diffLines, stats, similarity
+                              }
+                                        │
+                                        ▼
+                              Render in UI (side-by-side / unified)
+```
+
+### 2.3 Core Interfaces
+
+```typescript
+// ─── Input ───────────────────────────────────────────────────────────────────
+
+export interface ComparisonOptions {
+  /** Ignore leading/trailing whitespace when comparing */
+  ignoreWhitespace: boolean;
+  /** Case-insensitive comparison */
+  ignoreCase: boolean;
+  /** Skip empty/blank lines */
+  ignoreBlankLines: boolean;
+  /** Similarity threshold (0–1) for classifying a line as "modified" vs "added+removed" */
+  similarityThreshold: number;
+  /** For JSON: sort keys before comparing */
+  normalizeJson: boolean;
+  /** For CSV/XLSX: which sheet to compare (0-indexed) */
+  sheetIndex: number;
+}
+
+// ─── Output ──────────────────────────────────────────────────────────────────
+
+export interface ComparisonResult {
+  file1: FileMetadata;
+  file2: FileMetadata;
+  diffLines: DiffLine[];
+  stats: ComparisonStats;
+  similarity: number; // 0–100
+  duration: number;   // ms
+}
+
+export interface FileMetadata {
+  name: string;
+  size: number;
+  type: string;
+  lineCount: number;
+  extractedAt: number;
+}
+
+export interface DiffLine {
+  type: 'same' | 'added' | 'removed' | 'modified';
+  lineNumber1?: number;
+  lineNumber2?: number;
+  content: string;
+  oldContent?: string;
+  similarity?: number; // 0–100, only for 'modified'
+}
+
+export interface ComparisonStats {
+  totalLines: number;
+  sameLines: number;
+  addedLines: number;
+  removedLines: number;
+  modifiedLines: number;
+  similarityPercentage: number;
+}
+```
+
+### 2.4 Algorithm Details
+
+#### Line-Level Diff — Longest Common Subsequence (LCS)
+
+- Standard dynamic programming approach: O(m × n) time and space
+- For files > 10,000 lines: use Myers' diff algorithm (linear space optimization)
+- Output: sequence of operations (keep / insert / delete)
+
+#### Similarity Detection — Levenshtein Ratio
+
+For pairs of lines that are "delete from A" + "insert into B" and are adjacent:
+
+```
+ratio = 1 - (levenshteinDistance(lineA, lineB) / max(lineA.length, lineB.length))
+```
+
+- If `ratio >= similarityThreshold` (default 0.6) → classify as **modified**
+- Otherwise → keep as separate **added** + **removed**
+
+#### Overall Similarity Score
+
+```
+similarity = (sameLines + modifiedLines × avgModifiedSimilarity) / totalLines × 100
+```
+
+---
+
+## 3. Implementation Phases
+
+### Phase 1: Core Utility Module
+
+**Deliverable**: `src/utils/fileComparator.ts` — fully tested, no UI dependency
+
+#### Steps
+
+1. **Create file** `src/utils/fileComparator.ts`
+2. **Implement text extractors**:
+   - `extractTextFromPDF(file: File): Promise<string[]>` — reuse pattern from `knowledgeManager.ts`
+   - `extractTextFromDOCX(file: File): Promise<string[]>` — via `mammoth`
+   - `extractTextFromXLSX(file: File, sheetIndex: number): Promise<string[]>` — via `xlsx`
+   - `extractTextFromCSV(file: File): Promise<string[]>` — custom RFC 4180 parser
+   - `extractTextFromPlain(file: File): Promise<string[]>` — native FileReader
+   - `extractTextFromJSON(file: File, normalize: boolean): Promise<string[]>` — parse + stringify
+3. **Implement router** `extractText(file: File, options: ComparisonOptions): Promise<string[]>`
+   - Detect format from extension + MIME type
+   - Dispatch to correct extractor
+4. **Implement LCS diff** `computeLCS(a: string[], b: string[]): DiffLine[]`
+5. **Implement similarity scoring** using Levenshtein distance
+6. **Implement main entry** `compareFiles(file1: File, file2: File, options: ComparisonOptions): Promise<ComparisonResult>`
+7. **Export** all interfaces and the main class/functions
+
+#### Exit Criteria
+- All extractors handle valid + empty + malformed input gracefully
+- Diff produces correct output for known test vectors
+- No browser APIs used outside of `File` / `FileReader` / dynamic imports
+
+---
+
+### Phase 2: Unit Tests
+
+**Deliverable**: `src/utils/__tests__/fileComparator.test.ts`
+
+#### Test Cases
+
+| Category | Test |
+|----------|------|
+| **Extraction** | Plain text file reads correctly |
+| | JSON file is pretty-printed before diffing |
+| | CSV with quoted commas parses correctly |
+| | Unsupported format throws descriptive error |
+| **Diffing** | Two identical files → 100% similarity, all "same" |
+| | Completely different files → 0% similarity |
+| | Single line added → one "added" entry |
+| | Single line removed → one "removed" entry |
+| | Modified line detected when above threshold |
+| | Modified line NOT detected when below threshold |
+| **Options** | `ignoreWhitespace` trims before comparing |
+| | `ignoreCase` lowercases before comparing |
+| | `ignoreBlankLines` filters empty lines |
+| | `normalizeJson` sorts keys |
+| **Edge cases** | Empty file vs non-empty file |
+| | Very large file (>10K lines) completes in <5s |
+| | Binary file rejection with clear error message |
+
+#### Mocking Strategy
+- PDF/DOCX/XLSX extractors: mock the library imports, test integration separately
+- Text/CSV/JSON: use real `File` constructor with string data
+
+---
+
+### Phase 3: Install Dependencies
+
+**Deliverable**: Updated `package.json` with new packages
+
+```bash
+npm install mammoth xlsx
+```
+
+| Package | Version | Purpose | Bundle impact |
+|---------|---------|---------|---------------|
+| `mammoth` | ^1.8.0 | DOCX → plain text/HTML | ~50 KB gzip |
+| `xlsx` | ^0.18.5 | XLSX/XLS → JSON/text | ~90 KB gzip |
+
+> Both are lazy-imported (`import()`) to avoid impacting initial bundle size.
+
+---
+
+### Phase 4: UI Component
+
+**Deliverable**: `src/components/utils/FileComparator.tsx`
+
+#### Layout Structure
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ToolPageLayout (icon: 🔍, title: "File Comparator")        │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────────────────┐  ┌─────────────────────┐          │
+│  │   DROP FILE 1 HERE  │  │   DROP FILE 2 HERE  │          │
+│  │   (or click to      │  │   (or click to      │          │
+│  │    browse)          │  │    browse)          │          │
+│  └─────────────────────┘  └─────────────────────┘          │
+│                                                             │
+│  ┌─────────────────────────────────────────────────┐        │
+│  │ Options:                                         │        │
+│  │ ☑ Ignore whitespace  ☐ Ignore case              │        │
+│  │ ☐ Ignore blank lines  Threshold: [0.6]          │        │
+│  └─────────────────────────────────────────────────┘        │
+│                                                             │
+│  [ Compare Files ]                                          │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│  RESULTS                                                    │
+│  ┌─────────────────────────────────────────────────┐        │
+│  │ Similarity: ████████░░ 78%                       │        │
+│  │ Same: 156  Added: 12  Removed: 8  Modified: 24  │        │
+│  └─────────────────────────────────────────────────┘        │
+│                                                             │
+│  View: [Side-by-Side] [Unified]          [Export ▼]         │
+│                                                             │
+│  ┌────────────────────┬────────────────────┐                │
+│  │ File 1             │ File 2             │                │
+│  │ 1  same line       │ 1  same line       │                │
+│  │ 2  - removed line  │ 2  + added line    │                │
+│  │ 3  ~ modified old  │ 3  ~ modified new  │                │
+│  │ 4  same line       │ 4  same line       │                │
+│  └────────────────────┴────────────────────┘                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### UI Features
+
+| Feature | Implementation |
+|---------|---------------|
+| Drag & drop | HTML5 `ondragover`/`ondrop` with visual feedback |
+| File type badges | Show detected format + icon after upload |
+| Progress indicator | `ProgressBar` during extraction + diffing |
+| Syntax highlighting | Color-coded diff lines (green/red/yellow/gray) |
+| Line numbers | Gutter with aligned line numbers for both files |
+| Scroll sync | Side-by-side panels scroll together |
+| Export | Download as `.diff`, `.html` (styled), or `.json` |
+| Keyboard shortcuts | `Ctrl+Enter` to compare, `Ctrl+E` to export |
+
+#### Component State
+
+```typescript
+interface FileComparatorState {
+  file1: File | null;
+  file2: File | null;
+  options: ComparisonOptions;
+  result: ComparisonResult | null;
+  loading: boolean;
+  error: string | null;
+  viewMode: 'side-by-side' | 'unified';
+  highlightMode: 'line' | 'word';
+}
+```
+
+---
+
+### Phase 5: Route & Navigation Registration
+
+**Deliverable**: Tool accessible via URL and navigation menu
+
+#### 5.1 Route (`src/main.tsx`)
+
+```typescript
+// Add lazy import (alphabetical order with other file-related tools)
+const FileComparator = lazy(() => 
+  import('./components/utils/FileComparator.tsx')
+    .then(module => ({ default: module.FileComparator }))
+);
+
+// Add route entry
+{
+  path: 'file-comparator',
+  element: <RouteWrapper><FileComparator /></RouteWrapper>
+}
+```
+
+#### 5.2 Navigation (`src/config/navigationConfig.ts`)
+
+```typescript
+{
+  title: 'File Comparator',
+  description: 'Compare two files side-by-side — find same, similar, and different content across PDF, CSV, DOCX, XLSX, and more',
+  path: '#/file-comparator',
+  category: 'Testing Tools',
+  keywords: [
+    'file', 'compare', 'comparator', 'diff', 'difference', 'similar',
+    'same', 'pdf', 'csv', 'docx', 'xlsx', 'text', 'side-by-side',
+    'merge', 'changes', 'version', 'delta',
+  ],
+  icon: '🔍',
+  navGroups: ['Tools'],
+  navLabel: 'File Comparator',
+}
+```
+
+---
+
+### Phase 6: Integration Testing & QA
+
+**Deliverable**: Verified working feature with real-world files
+
+#### Manual Test Matrix
+
+| Scenario | File 1 | File 2 | Expected |
+|----------|--------|--------|----------|
+| Identical TXT | `a.txt` | `a.txt` (copy) | 100% similarity |
+| Small change TXT | `v1.txt` | `v2.txt` (1 line edit) | ~95% similarity, 1 modified |
+| PDF comparison | `report_v1.pdf` | `report_v2.pdf` | Structural diff shown |
+| CSV data diff | `export_jan.csv` | `export_feb.csv` | Row-level changes |
+| DOCX revision | `doc_draft.docx` | `doc_final.docx` | Paragraph-level diff |
+| XLSX sheet diff | `data_q1.xlsx` | `data_q2.xlsx` | Cell value changes |
+| Cross-format | `data.csv` | `data.xlsx` | Text extraction + compare |
+| Large file (>5MB) | Large PDF | Large PDF | Completes without crash |
+| Empty file | `empty.txt` | `content.txt` | 0% similarity |
+| Unsupported format | `file.zip` | `file.zip` | Clear error message |
+
+#### Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| Text extraction (< 1MB file) | < 1 second |
+| Diff computation (< 1000 lines) | < 500ms |
+| Diff computation (< 10,000 lines) | < 3 seconds |
+| UI render (< 5000 diff lines) | < 1 second |
+| Memory usage | < 200MB for any single comparison |
+
+---
+
+## 4. File Manifest
+
+### New Files
+
+| Path | Purpose |
+|------|---------|
+| `src/utils/fileComparator.ts` | Core comparison engine |
+| `src/utils/__tests__/fileComparator.test.ts` | Unit tests |
+| `src/components/utils/FileComparator.tsx` | React UI component |
+| `docs/plans/file-comparator.md` | This plan document |
+
+### Modified Files
+
+| Path | Change |
+|------|--------|
+| `src/main.tsx` | Add lazy import + route entry |
+| `src/config/navigationConfig.ts` | Add nav item |
+| `package.json` | Add `mammoth`, `xlsx` dependencies |
+
+---
+
+## 5. Dependencies
+
+### New Runtime Dependencies
+
+| Package | Version | License | Weekly Downloads | Justification |
+|---------|---------|---------|-----------------|---------------|
+| `mammoth` | ^1.8.0 | BSD-2 | ~500K | Industry standard for DOCX text extraction in JS |
+| `xlsx` | ^0.18.5 | Apache-2.0 | ~2M | Most popular XLSX parser for JavaScript |
+
+### Existing Dependencies Reused
+
+| Package | Usage |
+|---------|-------|
+| `pdfjs-dist` | PDF text extraction (already in `package.json`) |
+| `react-bootstrap` | UI components (Cards, Buttons, Badges, etc.) |
+
+### Import Strategy
+
+All heavy parsers are **lazy-loaded** via dynamic `import()` to preserve initial bundle performance:
+
+```typescript
+// Only loaded when user actually uploads a DOCX
+const mammoth = await import('mammoth');
+```
+
+---
+
+## 6. Testing Strategy
+
+### Unit Tests (Vitest)
+
+- **Location**: `src/utils/__tests__/fileComparator.test.ts`
+- **Framework**: Vitest (existing project standard)
+- **Mocking**: `vi.mock()` for PDF/DOCX/XLSX libraries; real `File` objects for text formats
+- **Coverage target**: ≥ 90% line coverage on `fileComparator.ts`
+
+### Component Tests (Optional, Phase 2+)
+
+- **Location**: `src/components/utils/__tests__/FileComparator.test.tsx`
+- **Framework**: `@testing-library/react` + Vitest
+- **Scope**: Upload interaction, button states, result rendering
+
+### Manual QA Checklist
+
+- [ ] Upload two files via drag & drop
+- [ ] Upload two files via file picker
+- [ ] Compare identical files → 100%
+- [ ] Compare very different files → low %
+- [ ] Toggle all options and verify effect
+- [ ] Switch between side-by-side and unified views
+- [ ] Export diff in all formats
+- [ ] Test with files > 5MB
+- [ ] Test with unsupported format → graceful error
+- [ ] Verify responsive layout on mobile viewport
+- [ ] Verify dark mode styling
+
+---
+
+## 7. Acceptance Criteria
+
+| # | Criterion | Verification |
+|---|-----------|-------------|
+| 1 | Tool is accessible at `#/file-comparator` | Navigate to URL |
+| 2 | Tool appears in navigation under "Tools" dropdown | Visual check |
+| 3 | Tool appears in search/command palette | Type "compare" in search |
+| 4 | Can upload and compare two TXT files | Manual test |
+| 5 | Can upload and compare two PDF files | Manual test |
+| 6 | Can upload and compare two CSV files | Manual test |
+| 7 | Can upload and compare two DOCX files | Manual test |
+| 8 | Can upload and compare two XLSX files | Manual test |
+| 9 | Similarity percentage is accurate (±5%) | Compare known files |
+| 10 | Side-by-side view shows aligned diff | Visual check |
+| 11 | Unified view shows inline diff | Visual check |
+| 12 | Options (whitespace, case, blank lines) work | Toggle and verify |
+| 13 | Export produces valid output | Download and open |
+| 14 | No console errors during normal usage | DevTools check |
+| 15 | All unit tests pass | `npm test` |
+| 16 | No regression in existing tests | `npm test` |
+| 17 | Page loads in < 2s on 3G throttle | Lighthouse |
+
+---
+
+## 8. Rollback Plan
+
+Since this is a **new, isolated feature** with no modifications to existing logic:
+
+1. **Revert route**: Remove the lazy import + route from `src/main.tsx`
+2. **Revert nav**: Remove the entry from `src/config/navigationConfig.ts`
+3. **Remove files**: Delete `src/utils/fileComparator.ts`, `src/components/utils/FileComparator.tsx`, test file
+4. **Remove deps** (if no other feature uses them): `npm uninstall mammoth xlsx`
+
+No existing functionality is affected at any point.
+
+---
+
+## 9. Future Enhancements (Out of Scope)
+
+| Enhancement | Description |
+|-------------|-------------|
+| Three-way merge | Compare base + two branches |
+| Folder comparison | Compare all files in two directories |
+| Inline editing | Edit one side and re-compare live |
+| AI summary | Use LLM to summarize what changed |
+| CLI support | `qautils compare file1.pdf file2.pdf` |
+| Syntax-aware diff | Parse code ASTs for smarter structural diff |
+| Image diff | Pixel-level comparison for image files |
+| Version history | Compare multiple versions of the same file |
+
+---
+
+## 10. References
+
+- [Myers Diff Algorithm Paper](http://www.xmailserver.org/diff2.pdf)
+- [pdfjs-dist documentation](https://mozilla.github.io/pdf.js/)
+- [mammoth.js GitHub](https://github.com/mwilliamson/mammoth.js)
+- [SheetJS documentation](https://docs.sheetjs.com/)
+- [RFC 4180 — CSV format](https://tools.ietf.org/html/rfc4180)
+- Existing pattern: `src/utils/knowledgeManager.ts` (PDF extraction)
+- Existing pattern: `src/components/utils/FileProcessor.tsx` (file upload UI)

--- a/docs/tools/testing-tools.md
+++ b/docs/tools/testing-tools.md
@@ -106,7 +106,83 @@ Visualize any API collection as an interactive tree diagram.
 
 ## 🧪 Testing Workflow
 
-### 🚀 CI/CD Workflow Generator
+### File Comparator
+
+Compare two files side-by-side — find same, similar, and different content across PDF, CSV, DOCX, XLSX, and text formats.
+
+- **Multi-format support** — PDF, DOCX, XLSX, CSV, JSON, TXT, Markdown, HTML, XML, and 30+ code/text formats
+- **Line-by-line diff** with LCS algorithm — same, added, removed, and modified classification
+- **Similarity scoring** — Levenshtein distance per-line, overall percentage
+- **Side-by-side and unified views** — toggle between diff display modes
+- **Comparison options** — ignore whitespace, case, blank lines; configurable similarity threshold
+- **Export** results as `.diff`, `.html`, or `.json`
+- **Drag & drop** file upload with format auto-detection
+- **Fullscreen modal** with zoom in/out for detailed inspection
+- Fully in-browser — no files leave your machine
+
+**Route:** `/file-comparator` &nbsp;|&nbsp; **CLI:** `qautils compare` &nbsp;|&nbsp; **API:** `POST /api/analysers/compare`
+
+#### CLI Usage
+
+```bash
+# Basic comparison
+qautils compare file1.txt file2.txt
+
+# Ignore whitespace and case differences
+qautils compare a.txt b.txt -w -i
+
+# Show stats summary only (no diff lines)
+qautils compare a.txt b.txt -f stats
+
+# JSON output (pipe-friendly)
+qautils compare a.txt b.txt -f json
+
+# Custom similarity threshold (80%)
+qautils compare a.txt b.txt -t 80
+
+# Ignore blank lines
+qautils compare a.txt b.txt -b
+```
+
+#### API Usage
+
+```bash
+curl -X POST http://localhost:3080/api/analysers/compare \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text1": "line 1\nline 2\nline 3",
+    "text2": "line 1\nline 2 modified\nline 4",
+    "ignoreWhitespace": false,
+    "ignoreCase": false,
+    "similarityThreshold": 0.6
+  }'
+```
+
+Response:
+
+```json
+{
+  "similarity": 33,
+  "stats": {
+    "totalLines": 4,
+    "sameLines": 1,
+    "addedLines": 1,
+    "removedLines": 1,
+    "modifiedLines": 1,
+    "similarityPercentage": 33
+  },
+  "diffLines": [
+    { "type": "same", "lineNumber1": 1, "lineNumber2": 1, "content": "line 1" },
+    { "type": "modified", "lineNumber1": 2, "lineNumber2": 2, "content": "line 2 modified", "oldContent": "line 2", "similarity": 80 },
+    { "type": "removed", "lineNumber1": 3, "content": "line 3" },
+    { "type": "added", "lineNumber2": 3, "content": "line 4" }
+  ]
+}
+```
+
+---
+
+### CI/CD Workflow Generator
 
 Generate production-ready CI/CD pipeline files for multiple platforms. *(Also listed under Developer Tools.)*
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "date-fns": "2.30.0",
     "humps": "2.0.1",
     "js-base64": "3.7.5",
+    "mammoth": "^1.12.0",
     "mermaid": "^11.12.2",
     "ora": "^9.3.0",
     "pdf-lib": "^1.17.1",
@@ -65,7 +66,8 @@
     "react-syntax-highlighter": "^15.6.1",
     "react-zoom-pan-pinch": "3.0.7",
     "use-ua-parser-js": "1.1.3",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
@@ -100,7 +102,7 @@
   "build": {
     "appId": "com.kobenguyent.qa-utils",
     "productName": "QA Utils",
-    "copyright": "Copyright \u00a9 2024 KobeT",
+    "copyright": "Copyright © 2024 KobeT",
     "directories": {
       "output": "release",
       "buildResources": "buildResources"

--- a/src/components/ExploreTools.tsx
+++ b/src/components/ExploreTools.tsx
@@ -26,8 +26,12 @@ export const ExploreTools: React.FC = () => {
     const map = new Map<string, typeof tools>();
     for (const tool of tools) {
       const cat = tool.category;
-      if (!map.has(cat)) map.set(cat, []);
-      map.get(cat)!.push(tool);
+      const existing = map.get(cat);
+      if (existing) {
+        existing.push(tool);
+      } else {
+        map.set(cat, [tool]);
+      }
     }
     return map;
   }, [tools]);

--- a/src/components/utils/FileComparator.tsx
+++ b/src/components/utils/FileComparator.tsx
@@ -1,0 +1,720 @@
+import React, { useState, useCallback, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { Card, Button, Form, Row, Col, Alert, ProgressBar, Badge, ButtonGroup } from 'react-bootstrap';
+import { ToolPageLayout } from './ToolPageLayout';
+import {
+  compareFiles,
+  ComparisonOptions,
+  ComparisonResult,
+  DiffLine,
+  DEFAULT_COMPARISON_OPTIONS,
+  getSupportedExtensions,
+  exportAsUnifiedDiff,
+  exportAsHTML,
+  exportAsJSON,
+} from '../../utils/fileComparator';
+
+type ViewMode = 'side-by-side' | 'unified';
+
+export const FileComparator: React.FC = () => {
+  const [file1, setFile1] = useState<File | null>(null);
+  const [file2, setFile2] = useState<File | null>(null);
+  const [options, setOptions] = useState<ComparisonOptions>(DEFAULT_COMPARISON_OPTIONS);
+  const [result, setResult] = useState<ComparisonResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('side-by-side');
+  const [progress, setProgress] = useState(0);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [zoom, setZoom] = useState(13);
+
+  const ZOOM_MIN = 9;
+  const ZOOM_MAX = 24;
+  const ZOOM_STEP = 1;
+
+  const zoomIn  = () => setZoom(z => Math.min(ZOOM_MAX, z + ZOOM_STEP));
+  const zoomOut = () => setZoom(z => Math.max(ZOOM_MIN, z - ZOOM_STEP));
+  const zoomReset = () => setZoom(13);
+
+  const file1Ref = useRef<HTMLInputElement>(null);
+  const file2Ref = useRef<HTMLInputElement>(null);
+  const diffContainerRef = useRef<HTMLDivElement>(null);
+
+  const supportedExts = getSupportedExtensions().map(e => `.${e}`).join(', ');
+
+  const handleFileDrop = useCallback((e: React.DragEvent, setter: (f: File) => void) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      setter(files[0]);
+      setError(null);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleCompare = async () => {
+    if (!file1 || !file2) {
+      setError('Please select two files to compare.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setProgress(10);
+
+    try {
+      setProgress(30);
+      const comparisonResult = await compareFiles(file1, file2, options);
+      setProgress(100);
+      setResult(comparisonResult);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred during comparison.');
+    } finally {
+      setLoading(false);
+      setTimeout(() => setProgress(0), 500);
+    }
+  };
+
+  const handleExport = (format: 'diff' | 'html' | 'json') => {
+    if (!result) return;
+
+    let content: string;
+    let mimeType: string;
+    let extension: string;
+
+    switch (format) {
+      case 'diff':
+        content = exportAsUnifiedDiff(result);
+        mimeType = 'text/plain';
+        extension = 'diff';
+        break;
+      case 'html':
+        content = exportAsHTML(result);
+        mimeType = 'text/html';
+        extension = 'html';
+        break;
+      case 'json':
+        content = exportAsJSON(result);
+        mimeType = 'application/json';
+        extension = 'json';
+        break;
+    }
+
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `comparison_${result.file1.name}_vs_${result.file2.name}.${extension}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleReset = () => {
+    setFile1(null);
+    setFile2(null);
+    setResult(null);
+    setError(null);
+    setProgress(0);
+    if (file1Ref.current) file1Ref.current.value = '';
+    if (file2Ref.current) file2Ref.current.value = '';
+  };
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleCompare();
+    }
+    if (e.key === 'Escape' && modalOpen) {
+      e.preventDefault();
+      setModalOpen(false);
+    }
+  }, [file1, file2, options, modalOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const getTypeIcon = (name: string): string => {
+    const ext = name.split('.').pop()?.toLowerCase() ?? '';
+    const icons: Record<string, string> = {
+      pdf: '📄', docx: '📝', xlsx: '📊', xls: '📊', csv: '📋',
+      json: '﹛﹜', txt: '📃', md: '📑', html: '🌐', xml: '📰',
+      js: '🟨', ts: '🔷', py: '🐍', java: '☕', sql: '🗄️',
+    };
+    return icons[ext] || '📁';
+  };
+
+  return (
+    <ToolPageLayout
+      icon="🔍"
+      title="File Comparator"
+      description="Compare two files side-by-side — find same, similar, and different content across PDF, CSV, DOCX, XLSX, and more"
+    >
+      <div onKeyDown={handleKeyDown} tabIndex={-1}>
+        {/* Upload Section */}
+        <Row className="mb-3 g-3">
+          <Col md={6}>
+            <Card className="glass-card h-100">
+              <Card.Body>
+                <div
+                  className="text-center p-4"
+                  style={{
+                    border: '2px dashed var(--border-color, #444)',
+                    borderRadius: '12px',
+                    cursor: 'pointer',
+                    transition: 'all 0.2s ease',
+                    minHeight: '140px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  onDragOver={handleDragOver}
+                  onDrop={(e) => handleFileDrop(e, setFile1)}
+                  onClick={() => file1Ref.current?.click()}
+                >
+                  <input
+                    ref={file1Ref}
+                    type="file"
+                    style={{ display: 'none' }}
+                    onChange={(e) => {
+                      if (e.target.files?.[0]) {
+                        setFile1(e.target.files[0]);
+                        setError(null);
+                      }
+                    }}
+                  />
+                  {file1 ? (
+                    <>
+                      <div style={{ fontSize: '2rem' }}>{getTypeIcon(file1.name)}</div>
+                      <strong className="mt-2">{file1.name}</strong>
+                      <small className="text-muted">{formatFileSize(file1.size)}</small>
+                    </>
+                  ) : (
+                    <>
+                      <div style={{ fontSize: '2rem', opacity: 0.5 }}>📂</div>
+                      <strong className="mt-2">File 1</strong>
+                      <small className="text-muted">Drop file here or click to browse</small>
+                    </>
+                  )}
+                </div>
+              </Card.Body>
+            </Card>
+          </Col>
+          <Col md={6}>
+            <Card className="glass-card h-100">
+              <Card.Body>
+                <div
+                  className="text-center p-4"
+                  style={{
+                    border: '2px dashed var(--border-color, #444)',
+                    borderRadius: '12px',
+                    cursor: 'pointer',
+                    transition: 'all 0.2s ease',
+                    minHeight: '140px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  onDragOver={handleDragOver}
+                  onDrop={(e) => handleFileDrop(e, setFile2)}
+                  onClick={() => file2Ref.current?.click()}
+                >
+                  <input
+                    ref={file2Ref}
+                    type="file"
+                    style={{ display: 'none' }}
+                    onChange={(e) => {
+                      if (e.target.files?.[0]) {
+                        setFile2(e.target.files[0]);
+                        setError(null);
+                      }
+                    }}
+                  />
+                  {file2 ? (
+                    <>
+                      <div style={{ fontSize: '2rem' }}>{getTypeIcon(file2.name)}</div>
+                      <strong className="mt-2">{file2.name}</strong>
+                      <small className="text-muted">{formatFileSize(file2.size)}</small>
+                    </>
+                  ) : (
+                    <>
+                      <div style={{ fontSize: '2rem', opacity: 0.5 }}>📂</div>
+                      <strong className="mt-2">File 2</strong>
+                      <small className="text-muted">Drop file here or click to browse</small>
+                    </>
+                  )}
+                </div>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+
+        {/* Supported formats hint */}
+        <div className="text-center mb-3">
+          <small className="text-muted">Supported: {supportedExts}</small>
+        </div>
+
+        {/* Options */}
+        <Card className="glass-card mb-3">
+          <Card.Body>
+            <h6 className="mb-3">Comparison Options</h6>
+            <Row className="g-3">
+              <Col sm={6} md={3}>
+                <Form.Check
+                  type="switch"
+                  id="ignoreWhitespace"
+                  label="Ignore whitespace"
+                  checked={options.ignoreWhitespace}
+                  onChange={(e) => setOptions(prev => ({ ...prev, ignoreWhitespace: e.target.checked }))}
+                />
+              </Col>
+              <Col sm={6} md={3}>
+                <Form.Check
+                  type="switch"
+                  id="ignoreCase"
+                  label="Ignore case"
+                  checked={options.ignoreCase}
+                  onChange={(e) => setOptions(prev => ({ ...prev, ignoreCase: e.target.checked }))}
+                />
+              </Col>
+              <Col sm={6} md={3}>
+                <Form.Check
+                  type="switch"
+                  id="ignoreBlankLines"
+                  label="Ignore blank lines"
+                  checked={options.ignoreBlankLines}
+                  onChange={(e) => setOptions(prev => ({ ...prev, ignoreBlankLines: e.target.checked }))}
+                />
+              </Col>
+              <Col sm={6} md={3}>
+                <Form.Check
+                  type="switch"
+                  id="normalizeJson"
+                  label="Normalize JSON keys"
+                  checked={options.normalizeJson}
+                  onChange={(e) => setOptions(prev => ({ ...prev, normalizeJson: e.target.checked }))}
+                />
+              </Col>
+              <Col sm={6} md={4}>
+                <Form.Label className="small mb-1">
+                  Similarity threshold: {Math.round(options.similarityThreshold * 100)}%
+                </Form.Label>
+                <Form.Range
+                  min={0}
+                  max={100}
+                  value={options.similarityThreshold * 100}
+                  onChange={(e) => setOptions(prev => ({
+                    ...prev,
+                    similarityThreshold: parseInt(e.target.value) / 100,
+                  }))}
+                />
+              </Col>
+              <Col sm={6} md={2}>
+                <Form.Label className="small mb-1">Sheet index</Form.Label>
+                <Form.Control
+                  type="number"
+                  size="sm"
+                  min={0}
+                  value={options.sheetIndex}
+                  onChange={(e) => setOptions(prev => ({
+                    ...prev,
+                    sheetIndex: parseInt(e.target.value) || 0,
+                  }))}
+                />
+              </Col>
+            </Row>
+          </Card.Body>
+        </Card>
+
+        {/* Action buttons */}
+        <div className="d-flex gap-2 mb-3 flex-wrap">
+          <Button
+            variant="primary"
+            onClick={handleCompare}
+            disabled={!file1 || !file2 || loading}
+            className="px-4"
+          >
+            {loading ? (
+              <>
+                <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                Comparing...
+              </>
+            ) : (
+              '🔍 Compare Files'
+            )}
+          </Button>
+          <Button variant="outline-secondary" onClick={handleReset} disabled={loading}>
+            Reset
+          </Button>
+          <small className="text-muted align-self-center ms-2">
+            Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to compare
+          </small>
+        </div>
+
+        {/* Progress */}
+        {loading && (
+          <ProgressBar animated now={progress} className="mb-3" style={{ height: '4px' }} />
+        )}
+
+        {/* Error */}
+        {error && (
+          <Alert variant="danger" dismissible onClose={() => setError(null)} className="mb-3">
+            {error}
+          </Alert>
+        )}
+
+        {/* Results */}
+        {result && (
+          <>
+            {/* Stats Summary */}
+            <Card className="glass-card mb-3">
+              <Card.Body>
+                <Row className="align-items-center g-3">
+                  <Col md={3} className="text-center">
+                    <div style={{ fontSize: '2.5rem', fontWeight: 700, color: getSimilarityColor(result.similarity) }}>
+                      {result.similarity}%
+                    </div>
+                    <small className="text-muted">Similarity</small>
+                    <ProgressBar
+                      now={result.similarity}
+                      className="mt-2"
+                      style={{ height: '6px' }}
+                      variant={result.similarity > 80 ? 'success' : result.similarity > 50 ? 'warning' : 'danger'}
+                    />
+                  </Col>
+                  <Col md={9}>
+                    <div className="d-flex flex-wrap gap-2">
+                      <Badge bg="secondary" className="px-3 py-2" style={{ fontSize: '0.85rem' }}>
+                        Total: {result.stats.totalLines}
+                      </Badge>
+                      <Badge bg="success" className="px-3 py-2" style={{ fontSize: '0.85rem' }}>
+                        Same: {result.stats.sameLines}
+                      </Badge>
+                      <Badge bg="info" className="px-3 py-2" style={{ fontSize: '0.85rem' }}>
+                        Added: {result.stats.addedLines}
+                      </Badge>
+                      <Badge bg="danger" className="px-3 py-2" style={{ fontSize: '0.85rem' }}>
+                        Removed: {result.stats.removedLines}
+                      </Badge>
+                      <Badge bg="warning" text="dark" className="px-3 py-2" style={{ fontSize: '0.85rem' }}>
+                        Modified: {result.stats.modifiedLines}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 text-muted small">
+                      Compared in {result.duration}ms &middot;
+                      {result.file1.name} ({result.file1.lineCount} lines) vs {result.file2.name} ({result.file2.lineCount} lines)
+                    </div>
+                  </Col>
+                </Row>
+              </Card.Body>
+            </Card>
+
+            {/* View controls + Export */}
+            <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+              <ButtonGroup size="sm">
+                <Button
+                  variant={viewMode === 'side-by-side' ? 'primary' : 'outline-secondary'}
+                  onClick={() => setViewMode('side-by-side')}
+                >
+                  Side-by-Side
+                </Button>
+                <Button
+                  variant={viewMode === 'unified' ? 'primary' : 'outline-secondary'}
+                  onClick={() => setViewMode('unified')}
+                >
+                  Unified
+                </Button>
+              </ButtonGroup>
+
+              <div className="d-flex align-items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setModalOpen(true)}
+                  title="Expand to fullscreen with zoom"
+                >
+                  ⛶ Expand
+                </Button>
+
+                <ButtonGroup size="sm">
+                  <Button variant="outline-secondary" onClick={() => handleExport('diff')}>
+                    Export .diff
+                  </Button>
+                  <Button variant="outline-secondary" onClick={() => handleExport('html')}>
+                    Export .html
+                  </Button>
+                  <Button variant="outline-secondary" onClick={() => handleExport('json')}>
+                    Export .json
+                  </Button>
+                </ButtonGroup>
+              </div>
+            </div>
+
+            {/* Diff View */}
+            <Card className="glass-card">
+              <Card.Body className="p-0">
+                <div
+                  ref={diffContainerRef}
+                  style={{
+                    maxHeight: '600px',
+                    overflowY: 'auto',
+                    fontFamily: '"Fira Code", "Cascadia Code", "JetBrains Mono", monospace',
+                    fontSize: '13px',
+                    lineHeight: '1.5',
+                  }}
+                >
+                  {viewMode === 'side-by-side' ? (
+                    <SideBySideView diffLines={result.diffLines} file1Name={result.file1.name} file2Name={result.file2.name} />
+                  ) : (
+                    <UnifiedView diffLines={result.diffLines} />
+                  )}
+                </div>
+              </Card.Body>
+            </Card>
+
+            {/* Fullscreen Modal — portalled to body to escape navbar stacking context */}
+            {modalOpen && ReactDOM.createPortal(
+              <div
+                style={{
+                  position: 'fixed',
+                  inset: 0,
+                  zIndex: 9999,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  backdropFilter: 'blur(12px)',
+                  WebkitBackdropFilter: 'blur(12px)',
+                  background: 'rgba(0, 0, 0, 0.7)',
+                }}
+                onClick={(e) => { if (e.target === e.currentTarget) setModalOpen(false); }}
+              >
+                {/* Modal toolbar */}
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '12px 20px',
+                    borderBottom: '1px solid rgba(108,112,134,0.3)',
+                    background: 'rgba(30, 30, 46, 0.95)',
+                    flexShrink: 0,
+                  }}
+                >
+                  <div className="d-flex align-items-center gap-3">
+                    <span style={{ fontWeight: 600, fontSize: '14px', opacity: 0.8 }}>
+                      {result.file1.name} vs {result.file2.name}
+                    </span>
+                    <ButtonGroup size="sm">
+                      <Button
+                        variant={viewMode === 'side-by-side' ? 'primary' : 'outline-secondary'}
+                        onClick={() => setViewMode('side-by-side')}
+                      >
+                        Side-by-Side
+                      </Button>
+                      <Button
+                        variant={viewMode === 'unified' ? 'primary' : 'outline-secondary'}
+                        onClick={() => setViewMode('unified')}
+                      >
+                        Unified
+                      </Button>
+                    </ButtonGroup>
+                  </div>
+
+                  <div className="d-flex align-items-center gap-2">
+                    <ButtonGroup size="sm">
+                      <Button
+                        variant="outline-light"
+                        onClick={zoomOut}
+                        disabled={zoom <= ZOOM_MIN}
+                        title="Zoom out"
+                        style={{ minWidth: '32px' }}
+                      >
+                        −
+                      </Button>
+                      <Button
+                        variant="outline-light"
+                        onClick={zoomReset}
+                        title="Reset zoom"
+                        style={{ minWidth: '52px', fontVariantNumeric: 'tabular-nums' }}
+                      >
+                        {zoom}px
+                      </Button>
+                      <Button
+                        variant="outline-light"
+                        onClick={zoomIn}
+                        disabled={zoom >= ZOOM_MAX}
+                        title="Zoom in"
+                        style={{ minWidth: '32px' }}
+                      >
+                        +
+                      </Button>
+                    </ButtonGroup>
+                    <Button
+                      size="sm"
+                      variant="outline-light"
+                      onClick={() => setModalOpen(false)}
+                      title="Close (Esc)"
+                      style={{ minWidth: '32px' }}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Modal diff content */}
+                <div
+                  style={{
+                    flex: 1,
+                    overflowY: 'auto',
+                    fontFamily: '"Fira Code", "Cascadia Code", "JetBrains Mono", monospace',
+                    fontSize: `${zoom}px`,
+                    lineHeight: '1.5',
+                    background: 'rgba(30, 30, 46, 0.95)',
+                  }}
+                >
+                  {viewMode === 'side-by-side' ? (
+                    <SideBySideView diffLines={result.diffLines} file1Name={result.file1.name} file2Name={result.file2.name} />
+                  ) : (
+                    <UnifiedView diffLines={result.diffLines} />
+                  )}
+                </div>
+              </div>,
+              document.body,
+            )}
+          </>
+        )}
+      </div>
+    </ToolPageLayout>
+  );
+};
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function getSimilarityColor(pct: number): string {
+  if (pct >= 80) return '#a6e3a1';
+  if (pct >= 50) return '#f9e2af';
+  return '#f38ba8';
+}
+
+const DIFF_COLORS: Record<DiffLine['type'], { bg: string; fg: string; symbol: string }> = {
+  same:     { bg: 'transparent',          fg: 'inherit',  symbol: ' ' },
+  added:    { bg: 'rgba(166,227,161,0.1)', fg: '#a6e3a1', symbol: '+' },
+  removed:  { bg: 'rgba(243,139,168,0.1)', fg: '#f38ba8', symbol: '-' },
+  modified: { bg: 'rgba(249,226,175,0.1)', fg: '#f9e2af', symbol: '~' },
+};
+
+const lineNumStyle: React.CSSProperties = {
+  width: '48px',
+  minWidth: '48px',
+  textAlign: 'right',
+  paddingRight: '8px',
+  color: '#6c7086',
+  userSelect: 'none',
+  borderRight: '1px solid rgba(108,112,134,0.2)',
+  flexShrink: 0,
+};
+
+const contentStyle: React.CSSProperties = {
+  padding: '0 8px',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+  flex: 1,
+  minWidth: 0,
+};
+
+const SideBySideView: React.FC<{ diffLines: DiffLine[]; file1Name: string; file2Name: string }> = ({
+  diffLines,
+  file1Name,
+  file2Name,
+}) => (
+  <div>
+    {/* Header */}
+    <div style={{ display: 'flex', borderBottom: '1px solid rgba(108,112,134,0.3)', position: 'sticky', top: 0, zIndex: 1, background: 'var(--card-bg, #1e1e2e)' }}>
+      <div style={{ flex: 1, padding: '8px 12px', fontWeight: 600, fontSize: '12px', opacity: 0.7 }}>{file1Name}</div>
+      <div style={{ width: '1px', background: 'rgba(108,112,134,0.3)' }} />
+      <div style={{ flex: 1, padding: '8px 12px', fontWeight: 600, fontSize: '12px', opacity: 0.7 }}>{file2Name}</div>
+    </div>
+    {diffLines.map((line, i) => (
+      <div key={i} style={{ display: 'flex', borderBottom: '1px solid rgba(108,112,134,0.08)' }}>
+        {/* Left side */}
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          background: line.type === 'removed' || line.type === 'modified'
+            ? 'rgba(243,139,168,0.08)' : DIFF_COLORS[line.type].bg,
+        }}>
+          <div style={lineNumStyle}>
+            {line.type === 'added' ? '' : line.lineNumber1 ?? ''}
+          </div>
+          <div style={{ ...contentStyle, color: line.type === 'removed' ? '#f38ba8' : line.type === 'modified' ? '#f9e2af' : 'inherit' }}>
+            {line.type === 'added' ? '' : (line.type === 'modified' ? line.oldContent : line.content)}
+          </div>
+        </div>
+        {/* Divider */}
+        <div style={{ width: '1px', background: 'rgba(108,112,134,0.2)', flexShrink: 0 }} />
+        {/* Right side */}
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          background: line.type === 'added' || line.type === 'modified'
+            ? 'rgba(166,227,161,0.08)' : DIFF_COLORS[line.type].bg,
+        }}>
+          <div style={lineNumStyle}>
+            {line.type === 'removed' ? '' : line.lineNumber2 ?? ''}
+          </div>
+          <div style={{ ...contentStyle, color: line.type === 'added' ? '#a6e3a1' : line.type === 'modified' ? '#a6e3a1' : 'inherit' }}>
+            {line.type === 'removed' ? '' : line.content}
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+const UnifiedView: React.FC<{ diffLines: DiffLine[] }> = ({ diffLines }) => (
+  <div>
+    {diffLines.map((line, i) => {
+      const colors = DIFF_COLORS[line.type];
+      if (line.type === 'modified') {
+        return (
+          <React.Fragment key={i}>
+            <div style={{ display: 'flex', background: 'rgba(243,139,168,0.08)', borderBottom: '1px solid rgba(108,112,134,0.08)' }}>
+              <div style={lineNumStyle}>{line.lineNumber1 ?? ''}</div>
+              <div style={{ width: '20px', textAlign: 'center', color: '#f38ba8', flexShrink: 0 }}>-</div>
+              <div style={{ ...contentStyle, color: '#f38ba8' }}>{line.oldContent}</div>
+            </div>
+            <div style={{ display: 'flex', background: 'rgba(166,227,161,0.08)', borderBottom: '1px solid rgba(108,112,134,0.08)' }}>
+              <div style={lineNumStyle}>{line.lineNumber2 ?? ''}</div>
+              <div style={{ width: '20px', textAlign: 'center', color: '#a6e3a1', flexShrink: 0 }}>+</div>
+              <div style={{ ...contentStyle, color: '#a6e3a1' }}>{line.content}</div>
+            </div>
+          </React.Fragment>
+        );
+      }
+      return (
+        <div key={i} style={{ display: 'flex', background: colors.bg, borderBottom: '1px solid rgba(108,112,134,0.08)' }}>
+          <div style={lineNumStyle}>
+            {line.lineNumber1 ?? line.lineNumber2 ?? ''}
+          </div>
+          <div style={{ width: '20px', textAlign: 'center', color: colors.fg, flexShrink: 0 }}>
+            {colors.symbol}
+          </div>
+          <div style={{ ...contentStyle, color: colors.fg }}>
+            {line.content}
+          </div>
+        </div>
+      );
+    })}
+  </div>
+);
+
+export default FileComparator;

--- a/src/components/utils/FileComparator.tsx
+++ b/src/components/utils/FileComparator.tsx
@@ -184,6 +184,7 @@ export const FileComparator: React.FC = () => {
                   <input
                     ref={file1Ref}
                     type="file"
+                    accept={supportedExts}
                     style={{ display: 'none' }}
                     onChange={(e) => {
                       if (e.target.files?.[0]) {
@@ -232,6 +233,7 @@ export const FileComparator: React.FC = () => {
                   <input
                     ref={file2Ref}
                     type="file"
+                    accept={supportedExts}
                     style={{ display: 'none' }}
                     onChange={(e) => {
                       if (e.target.files?.[0]) {

--- a/src/config/navigationConfig.ts
+++ b/src/config/navigationConfig.ts
@@ -530,6 +530,21 @@ export const navigationConfig: NavItem[] = [
     navGroups: ['Tools'],
   },
   {
+    title: 'File Comparator',
+    description:
+      'Compare two files side-by-side — find same, similar, and different content across PDF, CSV, DOCX, XLSX, and more',
+    path: '#/file-comparator',
+    category: 'Testing Tools',
+    keywords: [
+      'file', 'compare', 'comparator', 'diff', 'difference', 'similar',
+      'same', 'pdf', 'csv', 'docx', 'xlsx', 'text', 'side-by-side',
+      'merge', 'changes', 'version', 'delta',
+    ],
+    icon: '🔍',
+    navGroups: ['Tools'],
+    navLabel: 'File Comparator',
+  },
+  {
     title: 'Encryption/Decryption',
     description: 'Encrypt and decrypt text with various algorithms',
     path: '#/encryption',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -72,6 +72,7 @@ const ExploreTools = lazy(() => import('./components/ExploreTools.tsx'));
 const MarkdownToConfluence = lazy(() => import('./components/utils/MarkdownToConfluence.tsx').then(module => ({ default: module.MarkdownToConfluence })));
 // eslint-disable-next-line react-refresh/only-export-components
 const JsonPromptBuilder = lazy(() => import('./components/utils/JsonPromptBuilder.tsx').then(module => ({ default: module.JsonPromptBuilder })));
+const FileComparator = lazy(() => import('./components/utils/FileComparator.tsx').then(module => ({ default: module.FileComparator })));
 
 // Component wrapper with suspense for lazy loaded routes
 const RouteWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -338,6 +339,10 @@ const router = createHashRouter([
   {
     path: 'json-prompt-builder',
     element: <RouteWrapper><JsonPromptBuilder /></RouteWrapper>
+  },
+  {
+    path: 'file-comparator',
+    element: <RouteWrapper><FileComparator /></RouteWrapper>
   },
 ]);
 

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectFormat,
+  getSupportedExtensions,
+  extractTextFromPlain,
+  extractTextFromJSON,
+  extractTextFromCSV,
+  computeLCS,
+  levenshteinDistance,
+  computeLineSimilarity,
+  compareFiles,
+  exportAsUnifiedDiff,
+  exportAsHTML,
+  exportAsJSON,
+  DEFAULT_COMPARISON_OPTIONS,
+  ComparisonOptions,
+} from '../fileComparator';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createFile(content: string, name: string, type = 'text/plain'): File {
+  return new File([content], name, { type });
+}
+
+const defaultOpts: ComparisonOptions = { ...DEFAULT_COMPARISON_OPTIONS };
+
+// ─── Format Detection ────────────────────────────────────────────────────────
+
+describe('detectFormat', () => {
+  it('should detect PDF by extension', () => {
+    expect(detectFormat(createFile('', 'doc.pdf', 'application/pdf'))).toBe('pdf');
+  });
+
+  it('should detect DOCX by extension', () => {
+    expect(detectFormat(createFile('', 'doc.docx', ''))).toBe('docx');
+  });
+
+  it('should detect XLSX by extension', () => {
+    expect(detectFormat(createFile('', 'data.xlsx', ''))).toBe('xlsx');
+  });
+
+  it('should detect XLS by extension', () => {
+    expect(detectFormat(createFile('', 'data.xls', ''))).toBe('xlsx');
+  });
+
+  it('should detect CSV by extension', () => {
+    expect(detectFormat(createFile('', 'data.csv', 'text/csv'))).toBe('csv');
+  });
+
+  it('should detect TSV by extension', () => {
+    expect(detectFormat(createFile('', 'data.tsv', ''))).toBe('csv');
+  });
+
+  it('should detect JSON by extension', () => {
+    expect(detectFormat(createFile('', 'config.json', 'application/json'))).toBe('json');
+  });
+
+  it('should detect plain text formats', () => {
+    const plainExts = ['txt', 'log', 'md', 'html', 'xml', 'yaml', 'yml', 'js', 'ts', 'py', 'sql', 'css'];
+    for (const ext of plainExts) {
+      expect(detectFormat(createFile('', `file.${ext}`, 'text/plain'))).toBe('plain');
+    }
+  });
+
+  it('should fallback to MIME type when extension unknown', () => {
+    expect(detectFormat(createFile('', 'file', 'application/pdf'))).toBe('pdf');
+    expect(detectFormat(createFile('', 'file', 'text/csv'))).toBe('csv');
+    expect(detectFormat(createFile('', 'file', 'application/json'))).toBe('json');
+    expect(detectFormat(createFile('', 'file', 'text/plain'))).toBe('plain');
+  });
+
+  it('should throw for unsupported formats', () => {
+    expect(() => detectFormat(createFile('', 'file.zip', 'application/zip'))).toThrow('Unsupported file format');
+    expect(() => detectFormat(createFile('', 'file.exe', 'application/octet-stream'))).toThrow('Unsupported file format');
+  });
+});
+
+describe('getSupportedExtensions', () => {
+  it('should return an array of supported extensions', () => {
+    const exts = getSupportedExtensions();
+    expect(exts).toContain('pdf');
+    expect(exts).toContain('docx');
+    expect(exts).toContain('xlsx');
+    expect(exts).toContain('csv');
+    expect(exts).toContain('json');
+    expect(exts).toContain('txt');
+    expect(exts.length).toBeGreaterThan(10);
+  });
+});
+
+// ─── Text Extraction ─────────────────────────────────────────────────────────
+
+describe('extractTextFromPlain', () => {
+  it('should split file into lines', async () => {
+    const file = createFile('line 1\nline 2\nline 3', 'test.txt');
+    const lines = await extractTextFromPlain(file);
+    expect(lines).toEqual(['line 1', 'line 2', 'line 3']);
+  });
+
+  it('should handle empty file', async () => {
+    const file = createFile('', 'empty.txt');
+    const lines = await extractTextFromPlain(file);
+    expect(lines).toEqual(['']);
+  });
+
+  it('should handle single line', async () => {
+    const file = createFile('hello world', 'single.txt');
+    const lines = await extractTextFromPlain(file);
+    expect(lines).toEqual(['hello world']);
+  });
+});
+
+describe('extractTextFromJSON', () => {
+  it('should pretty-print and split JSON', async () => {
+    const file = createFile('{"a":1,"b":2}', 'data.json');
+    const lines = await extractTextFromJSON(file, false);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.join('\n')).toContain('"a": 1');
+  });
+
+  it('should normalize (sort keys) when enabled', async () => {
+    const file = createFile('{"z":1,"a":2}', 'data.json');
+    const lines = await extractTextFromJSON(file, true);
+    const joined = lines.join('\n');
+    const posA = joined.indexOf('"a"');
+    const posZ = joined.indexOf('"z"');
+    expect(posA).toBeLessThan(posZ);
+  });
+
+  it('should handle invalid JSON as plain text', async () => {
+    const file = createFile('not valid json {{{', 'bad.json');
+    const lines = await extractTextFromJSON(file, false);
+    expect(lines).toEqual(['not valid json {{{']);
+  });
+});
+
+describe('extractTextFromCSV', () => {
+  it('should parse simple CSV rows', async () => {
+    const file = createFile('name,age\nAlice,30\nBob,25', 'data.csv');
+    const lines = await extractTextFromCSV(file);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain('name');
+    expect(lines[0]).toContain('age');
+  });
+
+  it('should handle quoted fields with commas', async () => {
+    const file = createFile('"name","city"\n"Alice","New York, NY"\n"Bob","LA"', 'data.csv');
+    const lines = await extractTextFromCSV(file);
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain('New York, NY');
+  });
+
+  it('should handle escaped quotes in CSV', async () => {
+    const file = createFile('"say ""hello""","ok"', 'quotes.csv');
+    const lines = await extractTextFromCSV(file);
+    expect(lines[0]).toContain('say "hello"');
+  });
+
+  it('should handle empty CSV', async () => {
+    const file = createFile('', 'empty.csv');
+    const lines = await extractTextFromCSV(file);
+    expect(lines).toHaveLength(0);
+  });
+});
+
+// ─── Levenshtein & Similarity ────────────────────────────────────────────────
+
+describe('levenshteinDistance', () => {
+  it('should return 0 for identical strings', () => {
+    expect(levenshteinDistance('abc', 'abc')).toBe(0);
+  });
+
+  it('should return length of other string when one is empty', () => {
+    expect(levenshteinDistance('', 'abc')).toBe(3);
+    expect(levenshteinDistance('abc', '')).toBe(3);
+  });
+
+  it('should compute correct distance', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(3);
+    expect(levenshteinDistance('saturday', 'sunday')).toBe(3);
+  });
+
+  it('should return 1 for single character difference', () => {
+    expect(levenshteinDistance('cat', 'bat')).toBe(1);
+  });
+});
+
+describe('computeLineSimilarity', () => {
+  it('should return 1.0 for identical strings', () => {
+    expect(computeLineSimilarity('hello', 'hello')).toBe(1);
+  });
+
+  it('should return 0 for completely different strings of equal length', () => {
+    const sim = computeLineSimilarity('aaaa', 'zzzz');
+    expect(sim).toBe(0);
+  });
+
+  it('should return high similarity for minor changes', () => {
+    const sim = computeLineSimilarity('hello world', 'hello World');
+    expect(sim).toBeGreaterThan(0.8);
+  });
+
+  it('should return 1 for two empty strings', () => {
+    expect(computeLineSimilarity('', '')).toBe(1);
+  });
+});
+
+// ─── LCS Diff Algorithm ─────────────────────────────────────────────────────
+
+describe('computeLCS', () => {
+  it('should produce all "same" for identical arrays', () => {
+    const lines = ['a', 'b', 'c'];
+    const result = computeLCS(lines, [...lines], defaultOpts);
+    expect(result.every(d => d.type === 'same')).toBe(true);
+    expect(result).toHaveLength(3);
+  });
+
+  it('should detect added lines', () => {
+    const a = ['line 1', 'line 3'];
+    const b = ['line 1', 'line 2', 'line 3'];
+    const result = computeLCS(a, b, defaultOpts);
+    const added = result.filter(d => d.type === 'added');
+    expect(added).toHaveLength(1);
+    expect(added[0].content).toBe('line 2');
+  });
+
+  it('should detect removed lines', () => {
+    const a = ['line 1', 'line 2', 'line 3'];
+    const b = ['line 1', 'line 3'];
+    const result = computeLCS(a, b, defaultOpts);
+    const removed = result.filter(d => d.type === 'removed');
+    expect(removed).toHaveLength(1);
+    expect(removed[0].content).toBe('line 2');
+  });
+
+  it('should detect modified lines when above threshold', () => {
+    const a = ['hello world'];
+    const b = ['hello World'];
+    const result = computeLCS(a, b, { ...defaultOpts, similarityThreshold: 0.5 });
+    const modified = result.filter(d => d.type === 'modified');
+    expect(modified).toHaveLength(1);
+    expect(modified[0].oldContent).toBe('hello world');
+    expect(modified[0].content).toBe('hello World');
+    expect(modified[0].similarity).toBeGreaterThan(80);
+  });
+
+  it('should NOT merge as modified when below threshold', () => {
+    const a = ['completely different text'];
+    const b = ['xyz abc 123 !@#'];
+    const result = computeLCS(a, b, { ...defaultOpts, similarityThreshold: 0.9 });
+    const modified = result.filter(d => d.type === 'modified');
+    expect(modified).toHaveLength(0);
+  });
+
+  it('should handle empty arrays', () => {
+    expect(computeLCS([], [], defaultOpts)).toEqual([]);
+    const result = computeLCS(['a'], [], defaultOpts);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('removed');
+  });
+
+  it('should handle ignoreWhitespace option', () => {
+    const a = ['  hello  world  '];
+    const b = ['hello world'];
+    const result = computeLCS(a, b, { ...defaultOpts, ignoreWhitespace: true });
+    expect(result[0].type).toBe('same');
+  });
+
+  it('should handle ignoreCase option', () => {
+    const a = ['Hello World'];
+    const b = ['hello world'];
+    const result = computeLCS(a, b, { ...defaultOpts, ignoreCase: true });
+    expect(result[0].type).toBe('same');
+  });
+
+  it('should correctly number lines', () => {
+    const a = ['a', 'b', 'c'];
+    const b = ['a', 'x', 'c'];
+    const result = computeLCS(a, b, { ...defaultOpts, similarityThreshold: 0.1 });
+    const same1 = result.find(d => d.content === 'a');
+    expect(same1?.lineNumber1).toBe(1);
+    expect(same1?.lineNumber2).toBe(1);
+    const same3 = result.find(d => d.content === 'c');
+    expect(same3?.lineNumber1).toBe(3);
+    expect(same3?.lineNumber2).toBe(3);
+  });
+});
+
+// ─── compareFiles (integration — text files only) ────────────────────────────
+
+describe('compareFiles', () => {
+  it('should compare two identical text files', async () => {
+    const content = 'line 1\nline 2\nline 3';
+    const f1 = createFile(content, 'a.txt');
+    const f2 = createFile(content, 'b.txt');
+    const result = await compareFiles(f1, f2);
+
+    expect(result.similarity).toBe(100);
+    expect(result.stats.sameLines).toBe(3);
+    expect(result.stats.addedLines).toBe(0);
+    expect(result.stats.removedLines).toBe(0);
+    expect(result.stats.modifiedLines).toBe(0);
+    expect(result.file1.name).toBe('a.txt');
+    expect(result.file2.name).toBe('b.txt');
+    expect(result.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should compare two completely different text files', async () => {
+    const f1 = createFile('alpha\nbeta\ngamma', 'a.txt');
+    const f2 = createFile('one\ntwo\nthree', 'b.txt');
+    const result = await compareFiles(f1, f2);
+
+    expect(result.similarity).toBeLessThan(50);
+    expect(result.stats.sameLines).toBe(0);
+  });
+
+  it('should compare files with additions', async () => {
+    const f1 = createFile('a\nc', 'a.txt');
+    const f2 = createFile('a\nb\nc', 'b.txt');
+    const result = await compareFiles(f1, f2);
+
+    expect(result.stats.addedLines).toBe(1);
+    expect(result.stats.sameLines).toBe(2);
+  });
+
+  it('should compare files with removals', async () => {
+    const f1 = createFile('a\nb\nc', 'a.txt');
+    const f2 = createFile('a\nc', 'b.txt');
+    const result = await compareFiles(f1, f2);
+
+    expect(result.stats.removedLines).toBe(1);
+    expect(result.stats.sameLines).toBe(2);
+  });
+
+  it('should compare JSON files with normalization', async () => {
+    const f1 = createFile('{"z":1,"a":2}', 'a.json', 'application/json');
+    const f2 = createFile('{"a":2,"z":1}', 'b.json', 'application/json');
+    const result = await compareFiles(f1, f2, { normalizeJson: true });
+
+    expect(result.similarity).toBe(100);
+  });
+
+  it('should respect ignoreBlankLines option', async () => {
+    const f1 = createFile('a\n\nb', 'a.txt');
+    const f2 = createFile('a\nb', 'b.txt');
+    const result = await compareFiles(f1, f2, { ignoreBlankLines: true });
+
+    expect(result.similarity).toBe(100);
+    expect(result.stats.sameLines).toBe(2);
+  });
+
+  it('should handle empty file vs non-empty file', async () => {
+    const f1 = createFile('', 'empty.txt');
+    const f2 = createFile('some content', 'content.txt');
+    const result = await compareFiles(f1, f2, { ignoreBlankLines: true });
+
+    expect(result.similarity).toBe(0);
+  });
+
+  it('should throw for unsupported formats', async () => {
+    const f1 = createFile('', 'file.zip', 'application/zip');
+    const f2 = createFile('', 'file.zip', 'application/zip');
+    await expect(compareFiles(f1, f2)).rejects.toThrow('Unsupported file format');
+  });
+
+  it('should populate file metadata correctly', async () => {
+    const f1 = createFile('hello\nworld', 'test1.txt');
+    const f2 = createFile('hello\nearth', 'test2.txt');
+    const result = await compareFiles(f1, f2);
+
+    expect(result.file1.name).toBe('test1.txt');
+    expect(result.file2.name).toBe('test2.txt');
+    expect(result.file1.type).toBe('plain');
+    expect(result.file2.type).toBe('plain');
+    expect(result.file1.lineCount).toBe(2);
+    expect(result.file2.lineCount).toBe(2);
+    expect(result.file1.extractedAt).toBeGreaterThan(0);
+  });
+});
+
+// ─── Export Utilities ────────────────────────────────────────────────────────
+
+describe('exportAsUnifiedDiff', () => {
+  it('should produce valid unified diff format', async () => {
+    const f1 = createFile('same\nold line\nkeep', 'a.txt');
+    const f2 = createFile('same\nnew line\nkeep', 'b.txt');
+    const result = await compareFiles(f1, f2);
+    const diff = exportAsUnifiedDiff(result);
+
+    expect(diff).toContain('--- a.txt');
+    expect(diff).toContain('+++ b.txt');
+    expect(diff).toContain('same');
+  });
+});
+
+describe('exportAsHTML', () => {
+  it('should produce valid HTML', async () => {
+    const f1 = createFile('hello', 'a.txt');
+    const f2 = createFile('world', 'b.txt');
+    const result = await compareFiles(f1, f2);
+    const html = exportAsHTML(result);
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('a.txt');
+    expect(html).toContain('b.txt');
+    expect(html).toContain('<table>');
+  });
+
+  it('should escape HTML entities', async () => {
+    const f1 = createFile('<script>alert("xss")</script>', 'a.txt');
+    const f2 = createFile('<b>bold</b>', 'b.txt');
+    const result = await compareFiles(f1, f2);
+    const html = exportAsHTML(result);
+
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('exportAsJSON', () => {
+  it('should produce valid JSON string', async () => {
+    const f1 = createFile('a\nb', 'a.txt');
+    const f2 = createFile('a\nc', 'b.txt');
+    const result = await compareFiles(f1, f2);
+    const json = exportAsJSON(result);
+
+    const parsed = JSON.parse(json);
+    expect(parsed.similarity).toBeDefined();
+    expect(parsed.stats).toBeDefined();
+    expect(parsed.diffLines).toBeDefined();
+    expect(parsed.file1.name).toBe('a.txt');
+  });
+});

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -30,6 +30,10 @@ vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
   getDocument: pdfMocks.getDocument,
 }));
 
+vi.mock('pdfjs-dist/legacy/build/pdf.worker.mjs', () => ({
+  WorkerMessageHandler: {},
+}));
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function createFile(content: string, name: string, type = 'text/plain'): File {
@@ -179,6 +183,10 @@ describe('extractTextFromCSV', () => {
 
 describe('extractTextFromPDF', () => {
   const promiseWithResolversDescriptor = Object.getOwnPropertyDescriptor(Promise, 'withResolvers');
+  const promiseTryDescriptor = Object.getOwnPropertyDescriptor(Promise, 'try');
+  const arrayAtDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'at');
+  const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype) as { at?: unknown };
+  const typedArrayAtDescriptor = Object.getOwnPropertyDescriptor(typedArrayPrototype, 'at');
   const responseBytesDescriptor = Object.getOwnPropertyDescriptor(Response.prototype, 'bytes');
 
   afterEach(() => {
@@ -186,6 +194,24 @@ describe('extractTextFromPDF', () => {
       Object.defineProperty(Promise, 'withResolvers', promiseWithResolversDescriptor);
     } else {
       delete (Promise as PromiseConstructor & { withResolvers?: unknown }).withResolvers;
+    }
+
+    if (promiseTryDescriptor) {
+      Object.defineProperty(Promise, 'try', promiseTryDescriptor);
+    } else {
+      delete (Promise as PromiseConstructor & { try?: unknown }).try;
+    }
+
+    if (arrayAtDescriptor) {
+      Object.defineProperty(Array.prototype, 'at', arrayAtDescriptor);
+    } else {
+      delete (Array.prototype as unknown as { at?: unknown }).at;
+    }
+
+    if (typedArrayAtDescriptor) {
+      Object.defineProperty(typedArrayPrototype, 'at', typedArrayAtDescriptor);
+    } else {
+      delete typedArrayPrototype.at;
     }
 
     if (responseBytesDescriptor) {
@@ -213,6 +239,28 @@ describe('extractTextFromPDF', () => {
     const capability = Promise.withResolvers<string>();
     capability.resolve('ready');
     await expect(capability.promise).resolves.toBe('ready');
+  });
+
+  it('should install Promise.try when missing', async () => {
+    delete (Promise as PromiseConstructor & { try?: unknown }).try;
+
+    ensurePdfJsRuntimeCompatibility();
+
+    await expect(Promise.try(() => 'ready')).resolves.toBe('ready');
+    await expect(Promise.try((value: string) => value, 'arg')).resolves.toBe('arg');
+    await expect(Promise.try(() => {
+      throw new Error('boom');
+    })).rejects.toThrow('boom');
+  });
+
+  it('should install Array.at and typed-array at when missing', () => {
+    delete (Array.prototype as unknown as { at?: unknown }).at;
+    delete typedArrayPrototype.at;
+
+    ensurePdfJsRuntimeCompatibility();
+
+    expect(['a', 'b', 'c'].at(-1)).toBe('c');
+    expect(new Uint8Array([1, 2, 3]).at(-2)).toBe(2);
   });
 
   it('should install Response.bytes when missing', async () => {

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -23,6 +23,7 @@ const pdfMocks = vi.hoisted(() => ({
   getDocument: vi.fn(),
   getPage: vi.fn(),
   getTextContent: vi.fn(),
+  streamTextContent: vi.fn(),
 }));
 
 vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
@@ -223,8 +224,21 @@ describe('extractTextFromPDF', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    pdfMocks.getTextContent.mockResolvedValue({ items: [{ str: 'hello pdf' }] });
-    pdfMocks.getPage.mockResolvedValue({ getTextContent: pdfMocks.getTextContent });
+    pdfMocks.streamTextContent.mockReturnValue(new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          items: [{ str: 'hello pdf' }],
+          styles: {},
+          lang: null,
+        });
+        controller.close();
+      },
+    }));
+    pdfMocks.getTextContent.mockRejectedValue(new TypeError("undefined is not a function (near '...value of readableStream...')"));
+    pdfMocks.getPage.mockResolvedValue({
+      getTextContent: pdfMocks.getTextContent,
+      streamTextContent: pdfMocks.streamTextContent,
+    });
     pdfMocks.GlobalWorkerOptions.workerSrc = '';
     pdfMocks.getDocument.mockReturnValue({
       promise: Promise.resolve({ numPages: 1, getPage: pdfMocks.getPage }),
@@ -307,6 +321,15 @@ describe('extractTextFromPDF', () => {
     const firstArg = pdfMocks.getDocument.mock.calls[0][0] as { data?: unknown };
     expect(firstArg.data).toBeInstanceOf(Uint8Array);
     expect(pdfMocks.GlobalWorkerOptions.workerSrc).toContain('pdfjs-dist/legacy/build/pdf.worker.min.mjs');
+  });
+
+  it('should read PDF text via stream reader instead of ReadableStream async iteration', async () => {
+    const file = createFile('%PDF-1.4', 'test.pdf', 'application/pdf');
+
+    await expect(extractTextFromPDF(file)).resolves.toEqual(['hello pdf']);
+
+    expect(pdfMocks.streamTextContent).toHaveBeenCalledTimes(1);
+    expect(pdfMocks.getTextContent).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -19,13 +19,14 @@ import {
 } from '../fileComparator';
 
 const pdfMocks = vi.hoisted(() => ({
+  GlobalWorkerOptions: { workerSrc: '' },
   getDocument: vi.fn(),
   getPage: vi.fn(),
   getTextContent: vi.fn(),
 }));
 
 vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
-  GlobalWorkerOptions: { workerSrc: '' },
+  GlobalWorkerOptions: pdfMocks.GlobalWorkerOptions,
   getDocument: pdfMocks.getDocument,
 }));
 
@@ -198,6 +199,7 @@ describe('extractTextFromPDF', () => {
     vi.clearAllMocks();
     pdfMocks.getTextContent.mockResolvedValue({ items: [{ str: 'hello pdf' }] });
     pdfMocks.getPage.mockResolvedValue({ getTextContent: pdfMocks.getTextContent });
+    pdfMocks.GlobalWorkerOptions.workerSrc = '';
     pdfMocks.getDocument.mockReturnValue({
       promise: Promise.resolve({ numPages: 1, getPage: pdfMocks.getPage }),
     });
@@ -248,15 +250,15 @@ describe('extractTextFromPDF', () => {
     expect(Response.prototype.bytes).toBe(existingBytes);
   });
 
-  it('should pass Uint8Array data and disable workers for PDF.js getDocument', async () => {
+  it('should pass Uint8Array data and configure the matching legacy worker', async () => {
     const file = createFile('%PDF-1.4', 'test.pdf', 'application/pdf');
     const lines = await extractTextFromPDF(file);
 
     expect(lines).toEqual(['hello pdf']);
     expect(pdfMocks.getDocument).toHaveBeenCalledTimes(1);
-    const firstArg = pdfMocks.getDocument.mock.calls[0][0] as { data?: unknown; disableWorker?: unknown };
+    const firstArg = pdfMocks.getDocument.mock.calls[0][0] as { data?: unknown };
     expect(firstArg.data).toBeInstanceOf(Uint8Array);
-    expect(firstArg.disableWorker).toBe(true);
+    expect(pdfMocks.GlobalWorkerOptions.workerSrc).toContain('pdfjs-dist/legacy/build/pdf.worker.min.mjs');
   });
 });
 

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -23,7 +23,7 @@ const pdfMocks = vi.hoisted(() => ({
   getTextContent: vi.fn(),
 }));
 
-vi.mock('pdfjs-dist', () => ({
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
   GlobalWorkerOptions: { workerSrc: '' },
   getDocument: pdfMocks.getDocument,
 }));

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   detectFormat,
   getSupportedExtensions,
@@ -6,6 +6,7 @@ import {
   extractTextFromJSON,
   extractTextFromCSV,
   extractTextFromPDF,
+  ensurePdfJsRuntimeCompatibility,
   computeLCS,
   levenshteinDistance,
   computeLineSimilarity,
@@ -176,6 +177,23 @@ describe('extractTextFromCSV', () => {
 });
 
 describe('extractTextFromPDF', () => {
+  const promiseWithResolversDescriptor = Object.getOwnPropertyDescriptor(Promise, 'withResolvers');
+  const responseBytesDescriptor = Object.getOwnPropertyDescriptor(Response.prototype, 'bytes');
+
+  afterEach(() => {
+    if (promiseWithResolversDescriptor) {
+      Object.defineProperty(Promise, 'withResolvers', promiseWithResolversDescriptor);
+    } else {
+      delete (Promise as PromiseConstructor & { withResolvers?: unknown }).withResolvers;
+    }
+
+    if (responseBytesDescriptor) {
+      Object.defineProperty(Response.prototype, 'bytes', responseBytesDescriptor);
+    } else {
+      delete (Response.prototype as Response & { bytes?: unknown }).bytes;
+    }
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     pdfMocks.getTextContent.mockResolvedValue({ items: [{ str: 'hello pdf' }] });
@@ -185,14 +203,60 @@ describe('extractTextFromPDF', () => {
     });
   });
 
-  it('should pass Uint8Array data to PDF.js getDocument', async () => {
+  it('should install Promise.withResolvers when missing', async () => {
+    delete (Promise as PromiseConstructor & { withResolvers?: unknown }).withResolvers;
+
+    ensurePdfJsRuntimeCompatibility();
+
+    const capability = Promise.withResolvers<string>();
+    capability.resolve('ready');
+    await expect(capability.promise).resolves.toBe('ready');
+  });
+
+  it('should install Response.bytes when missing', async () => {
+    delete (Response.prototype as Response & { bytes?: unknown }).bytes;
+
+    ensurePdfJsRuntimeCompatibility();
+
+    const bytes = await new Response('pdf').bytes();
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(bytes)).toEqual([112, 100, 102]);
+  });
+
+  it('should not overwrite native compatibility APIs', () => {
+    const existingWithResolvers = vi.fn(() => ({
+      promise: Promise.resolve('native'),
+      resolve: vi.fn(),
+      reject: vi.fn(),
+    }));
+    const existingBytes = vi.fn(async () => new Uint8Array([1, 2, 3]));
+
+    Object.defineProperty(Promise, 'withResolvers', {
+      configurable: true,
+      writable: true,
+      value: existingWithResolvers,
+    });
+    Object.defineProperty(Response.prototype, 'bytes', {
+      configurable: true,
+      writable: true,
+      value: existingBytes,
+    });
+
+    ensurePdfJsRuntimeCompatibility();
+
+    expect(Promise.withResolvers).toBe(existingWithResolvers);
+    expect(Response.prototype.bytes).toBe(existingBytes);
+  });
+
+  it('should pass Uint8Array data and disable workers for PDF.js getDocument', async () => {
     const file = createFile('%PDF-1.4', 'test.pdf', 'application/pdf');
     const lines = await extractTextFromPDF(file);
 
     expect(lines).toEqual(['hello pdf']);
     expect(pdfMocks.getDocument).toHaveBeenCalledTimes(1);
-    const firstArg = pdfMocks.getDocument.mock.calls[0][0] as { data?: unknown };
+    const firstArg = pdfMocks.getDocument.mock.calls[0][0] as { data?: unknown; disableWorker?: unknown };
     expect(firstArg.data).toBeInstanceOf(Uint8Array);
+    expect(firstArg.disableWorker).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/fileComparator.test.ts
+++ b/src/utils/__tests__/fileComparator.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   detectFormat,
   getSupportedExtensions,
   extractTextFromPlain,
   extractTextFromJSON,
   extractTextFromCSV,
+  extractTextFromPDF,
   computeLCS,
   levenshteinDistance,
   computeLineSimilarity,
@@ -15,6 +16,17 @@ import {
   DEFAULT_COMPARISON_OPTIONS,
   ComparisonOptions,
 } from '../fileComparator';
+
+const pdfMocks = vi.hoisted(() => ({
+  getDocument: vi.fn(),
+  getPage: vi.fn(),
+  getTextContent: vi.fn(),
+}));
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: pdfMocks.getDocument,
+}));
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -160,6 +172,27 @@ describe('extractTextFromCSV', () => {
     const file = createFile('', 'empty.csv');
     const lines = await extractTextFromCSV(file);
     expect(lines).toHaveLength(0);
+  });
+});
+
+describe('extractTextFromPDF', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pdfMocks.getTextContent.mockResolvedValue({ items: [{ str: 'hello pdf' }] });
+    pdfMocks.getPage.mockResolvedValue({ getTextContent: pdfMocks.getTextContent });
+    pdfMocks.getDocument.mockReturnValue({
+      promise: Promise.resolve({ numPages: 1, getPage: pdfMocks.getPage }),
+    });
+  });
+
+  it('should pass Uint8Array data to PDF.js getDocument', async () => {
+    const file = createFile('%PDF-1.4', 'test.pdf', 'application/pdf');
+    const lines = await extractTextFromPDF(file);
+
+    expect(lines).toEqual(['hello pdf']);
+    expect(pdfMocks.getDocument).toHaveBeenCalledTimes(1);
+    const firstArg = pdfMocks.getDocument.mock.calls[0][0] as { data?: unknown };
+    expect(firstArg.data).toBeInstanceOf(Uint8Array);
   });
 });
 

--- a/src/utils/colorAccessibility.ts
+++ b/src/utils/colorAccessibility.ts
@@ -8,8 +8,9 @@ const maxCacheSize = 1000;
 export const getCachedConversion = (input: ColorInput): ColorFormats => {
   const key = JSON.stringify(input);
   
-  if (conversionCache.has(key)) {
-    return conversionCache.get(key)!;
+  const cached = conversionCache.get(key);
+  if (cached) {
+    return cached;
   }
   
   const result = convertColor(input);

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -1,0 +1,618 @@
+// ─── Interfaces ──────────────────────────────────────────────────────────────
+
+export interface ComparisonOptions {
+  ignoreWhitespace: boolean;
+  ignoreCase: boolean;
+  ignoreBlankLines: boolean;
+  similarityThreshold: number;
+  normalizeJson: boolean;
+  sheetIndex: number;
+}
+
+export const DEFAULT_COMPARISON_OPTIONS: ComparisonOptions = {
+  ignoreWhitespace: false,
+  ignoreCase: false,
+  ignoreBlankLines: false,
+  similarityThreshold: 0.6,
+  normalizeJson: true,
+  sheetIndex: 0,
+};
+
+export interface FileMetadata {
+  name: string;
+  size: number;
+  type: string;
+  lineCount: number;
+  extractedAt: number;
+}
+
+export interface ComparisonResult {
+  file1: FileMetadata;
+  file2: FileMetadata;
+  diffLines: DiffLine[];
+  stats: ComparisonStats;
+  similarity: number;
+  duration: number;
+}
+
+export interface DiffLine {
+  type: 'same' | 'added' | 'removed' | 'modified';
+  lineNumber1?: number;
+  lineNumber2?: number;
+  content: string;
+  oldContent?: string;
+  similarity?: number;
+}
+
+export interface ComparisonStats {
+  totalLines: number;
+  sameLines: number;
+  addedLines: number;
+  removedLines: number;
+  modifiedLines: number;
+  similarityPercentage: number;
+}
+
+// ─── Format Detection ────────────────────────────────────────────────────────
+
+type SupportedFormat = 'pdf' | 'docx' | 'xlsx' | 'csv' | 'json' | 'plain';
+
+const EXTENSION_MAP: Record<string, SupportedFormat> = {
+  pdf: 'pdf',
+  docx: 'docx',
+  xlsx: 'xlsx',
+  xls: 'xlsx',
+  csv: 'csv',
+  tsv: 'csv',
+  json: 'json',
+  txt: 'plain',
+  log: 'plain',
+  md: 'plain',
+  html: 'plain',
+  htm: 'plain',
+  xml: 'plain',
+  yaml: 'plain',
+  yml: 'plain',
+  ini: 'plain',
+  cfg: 'plain',
+  conf: 'plain',
+  env: 'plain',
+  sh: 'plain',
+  bat: 'plain',
+  py: 'plain',
+  js: 'plain',
+  ts: 'plain',
+  jsx: 'plain',
+  tsx: 'plain',
+  css: 'plain',
+  scss: 'plain',
+  sql: 'plain',
+  java: 'plain',
+  rb: 'plain',
+  go: 'plain',
+  rs: 'plain',
+  c: 'plain',
+  cpp: 'plain',
+  h: 'plain',
+  swift: 'plain',
+  kt: 'plain',
+  php: 'plain',
+};
+
+export function detectFormat(file: File): SupportedFormat {
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  const mapped = EXTENSION_MAP[ext];
+  if (mapped) return mapped;
+
+  // Fallback to MIME type
+  if (file.type === 'application/pdf') return 'pdf';
+  if (file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') return 'docx';
+  if (file.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+      file.type === 'application/vnd.ms-excel') return 'xlsx';
+  if (file.type === 'text/csv') return 'csv';
+  if (file.type === 'application/json') return 'json';
+  if (file.type.startsWith('text/')) return 'plain';
+
+  throw new Error(`Unsupported file format: .${ext || 'unknown'} (${file.type || 'no MIME type'}). Supported: PDF, DOCX, XLSX, CSV, JSON, TXT, and other text formats.`);
+}
+
+export function getSupportedExtensions(): string[] {
+  return Object.keys(EXTENSION_MAP);
+}
+
+// ─── Text Extractors ─────────────────────────────────────────────────────────
+
+async function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
+    reader.readAsText(file);
+  });
+}
+
+async function readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+export async function extractTextFromPlain(file: File): Promise<string[]> {
+  const text = await readFileAsText(file);
+  return text.split('\n');
+}
+
+export async function extractTextFromJSON(file: File, normalize: boolean): Promise<string[]> {
+  const text = await readFileAsText(file);
+  try {
+    const parsed = JSON.parse(text);
+    const formatted = normalize
+      ? JSON.stringify(parsed, Object.keys(parsed).sort(), 2)
+      : JSON.stringify(parsed, null, 2);
+    return formatted.split('\n');
+  } catch {
+    // If JSON is invalid, treat as plain text
+    return text.split('\n');
+  }
+}
+
+export async function extractTextFromCSV(file: File): Promise<string[]> {
+  const text = await readFileAsText(file);
+  return parseCSVToLines(text);
+}
+
+/** RFC 4180-compliant CSV parser that normalizes rows into readable lines */
+function parseCSVToLines(text: string): string[] {
+  const lines: string[] = [];
+  const rows = parseCSVRows(text);
+
+  for (const row of rows) {
+    lines.push(row.join(' | '));
+  }
+
+  return lines;
+}
+
+function parseCSVRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let current = '';
+  let inQuotes = false;
+  let row: string[] = [];
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const next = text[i + 1];
+
+    if (inQuotes) {
+      if (char === '"' && next === '"') {
+        current += '"';
+        i++; // skip escaped quote
+      } else if (char === '"') {
+        inQuotes = false;
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',' || char === '\t') {
+        row.push(current.trim());
+        current = '';
+      } else if (char === '\n' || (char === '\r' && next === '\n')) {
+        row.push(current.trim());
+        if (row.some(cell => cell !== '')) {
+          rows.push(row);
+        }
+        row = [];
+        current = '';
+        if (char === '\r') i++; // skip \n in \r\n
+      } else {
+        current += char;
+      }
+    }
+  }
+
+  // Last row
+  row.push(current.trim());
+  if (row.some(cell => cell !== '')) {
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+export async function extractTextFromPDF(file: File): Promise<string[]> {
+  try {
+    const pdfjsLib = await import('pdfjs-dist');
+    pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+      'pdfjs-dist/build/pdf.worker.min.mjs',
+      import.meta.url
+    ).href;
+
+    const arrayBuffer = await readFileAsArrayBuffer(file);
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    const lines: string[] = [];
+
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const textContent = await page.getTextContent();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pageText = textContent.items
+        .map((item: any) => (item && typeof item.str === 'string' ? item.str : ''))
+        .join('');
+      const pageLines = pageText.split('\n').filter((l: string) => l.trim() !== '');
+      if (pageLines.length > 0) {
+        lines.push(...pageLines);
+      } else if (pageText.trim()) {
+        lines.push(pageText.trim());
+      }
+    }
+
+    return lines.length > 0 ? lines : ['(Empty PDF — no extractable text)'];
+  } catch (err) {
+    throw new Error(`Failed to extract text from PDF: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export async function extractTextFromDOCX(file: File): Promise<string[]> {
+  try {
+    const mammoth = await import('mammoth');
+    const arrayBuffer = await readFileAsArrayBuffer(file);
+    const result = await mammoth.extractRawText({ arrayBuffer });
+    const lines = result.value.split('\n').filter((l: string) => l !== '');
+    return lines.length > 0 ? lines : ['(Empty document — no extractable text)'];
+  } catch (err) {
+    throw new Error(`Failed to extract text from DOCX: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export async function extractTextFromXLSX(file: File, sheetIndex: number): Promise<string[]> {
+  try {
+    const XLSX = await import('xlsx');
+    const arrayBuffer = await readFileAsArrayBuffer(file);
+    const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+
+    const sheetName = workbook.SheetNames[sheetIndex];
+    if (!sheetName) {
+      throw new Error(`Sheet index ${sheetIndex} not found. Available sheets: ${workbook.SheetNames.join(', ')}`);
+    }
+
+    const sheet = workbook.Sheets[sheetName];
+    const rows: string[][] = XLSX.utils.sheet_to_json(sheet, { header: 1 }) as string[][];
+    const lines = rows
+      .filter((row: string[]) => row.some((cell: string) => cell !== undefined && cell !== null && String(cell).trim() !== ''))
+      .map((row: string[]) => row.map((cell: string) => (cell !== undefined && cell !== null ? String(cell) : '')).join(' | '));
+
+    return lines.length > 0 ? lines : ['(Empty spreadsheet — no data)'];
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Sheet index')) throw err;
+    throw new Error(`Failed to extract text from XLSX: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// ─── Extraction Router ───────────────────────────────────────────────────────
+
+export async function extractText(file: File, options: ComparisonOptions): Promise<string[]> {
+  const format = detectFormat(file);
+
+  let lines: string[];
+  switch (format) {
+    case 'pdf':
+      lines = await extractTextFromPDF(file);
+      break;
+    case 'docx':
+      lines = await extractTextFromDOCX(file);
+      break;
+    case 'xlsx':
+      lines = await extractTextFromXLSX(file, options.sheetIndex);
+      break;
+    case 'csv':
+      lines = await extractTextFromCSV(file);
+      break;
+    case 'json':
+      lines = await extractTextFromJSON(file, options.normalizeJson);
+      break;
+    case 'plain':
+    default:
+      lines = await extractTextFromPlain(file);
+      break;
+  }
+
+  // Apply pre-processing options
+  if (options.ignoreBlankLines) {
+    lines = lines.filter(line => line.trim() !== '');
+  }
+
+  return lines;
+}
+
+// ─── Diff Algorithm (LCS-based) ──────────────────────────────────────────────
+
+export function computeLCS(a: string[], b: string[], options: ComparisonOptions): DiffLine[] {
+  const normalize = (s: string): string => {
+    let result = s;
+    if (options.ignoreWhitespace) result = result.replace(/\s+/g, ' ').trim();
+    if (options.ignoreCase) result = result.toLowerCase();
+    return result;
+  };
+
+  const m = a.length;
+  const n = b.length;
+
+  // Build LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (normalize(a[i - 1]) === normalize(b[j - 1])) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Backtrack to build diff
+  const rawDiff: Array<{ type: 'same' | 'removed' | 'added'; indexA: number; indexB: number }> = [];
+  let i = m, j = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && normalize(a[i - 1]) === normalize(b[j - 1])) {
+      rawDiff.unshift({ type: 'same', indexA: i - 1, indexB: j - 1 });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      rawDiff.unshift({ type: 'added', indexA: -1, indexB: j - 1 });
+      j--;
+    } else {
+      rawDiff.unshift({ type: 'removed', indexA: i - 1, indexB: -1 });
+      i--;
+    }
+  }
+
+  // Post-process: detect "modified" lines (adjacent removed + added with high similarity)
+  const diffLines: DiffLine[] = [];
+  let idx = 0;
+
+  while (idx < rawDiff.length) {
+    const entry = rawDiff[idx];
+
+    if (entry.type === 'removed' && idx + 1 < rawDiff.length && rawDiff[idx + 1].type === 'added') {
+      const removedLine = a[entry.indexA];
+      const addedLine = b[rawDiff[idx + 1].indexB];
+      const sim = computeLineSimilarity(normalize(removedLine), normalize(addedLine));
+
+      if (sim >= options.similarityThreshold) {
+        diffLines.push({
+          type: 'modified',
+          lineNumber1: entry.indexA + 1,
+          lineNumber2: rawDiff[idx + 1].indexB + 1,
+          content: addedLine,
+          oldContent: removedLine,
+          similarity: Math.round(sim * 100),
+        });
+        idx += 2;
+        continue;
+      }
+    }
+
+    if (entry.type === 'same') {
+      diffLines.push({
+        type: 'same',
+        lineNumber1: entry.indexA + 1,
+        lineNumber2: entry.indexB + 1,
+        content: a[entry.indexA],
+      });
+    } else if (entry.type === 'removed') {
+      diffLines.push({
+        type: 'removed',
+        lineNumber1: entry.indexA + 1,
+        content: a[entry.indexA],
+      });
+    } else {
+      diffLines.push({
+        type: 'added',
+        lineNumber2: entry.indexB + 1,
+        content: b[entry.indexB],
+      });
+    }
+
+    idx++;
+  }
+
+  return diffLines;
+}
+
+// ─── Similarity Scoring ──────────────────────────────────────────────────────
+
+export function levenshteinDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  // Use two-row optimization for space efficiency
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr = new Array(n + 1);
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j] + 1,      // deletion
+        curr[j - 1] + 1,  // insertion
+        prev[j - 1] + cost // substitution
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[n];
+}
+
+export function computeLineSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshteinDistance(a, b) / maxLen;
+}
+
+function computeStats(diffLines: DiffLine[]): ComparisonStats {
+  const sameLines = diffLines.filter(d => d.type === 'same').length;
+  const addedLines = diffLines.filter(d => d.type === 'added').length;
+  const removedLines = diffLines.filter(d => d.type === 'removed').length;
+  const modifiedEntries = diffLines.filter(d => d.type === 'modified');
+  const modifiedLines = modifiedEntries.length;
+  const totalLines = diffLines.length;
+
+  // Similarity: same lines count fully, modified lines count proportionally
+  const modifiedSimilaritySum = modifiedEntries.reduce((sum, d) => sum + (d.similarity || 0) / 100, 0);
+  const effectiveSame = sameLines + modifiedSimilaritySum;
+  const maxLines = Math.max(totalLines, 1);
+  const similarityPercentage = Math.round((effectiveSame / maxLines) * 100);
+
+  return {
+    totalLines,
+    sameLines,
+    addedLines,
+    removedLines,
+    modifiedLines,
+    similarityPercentage: Math.min(100, Math.max(0, similarityPercentage)),
+  };
+}
+
+// ─── Main Entry Point ────────────────────────────────────────────────────────
+
+export async function compareFiles(
+  file1: File,
+  file2: File,
+  options: Partial<ComparisonOptions> = {}
+): Promise<ComparisonResult> {
+  const opts: ComparisonOptions = { ...DEFAULT_COMPARISON_OPTIONS, ...options };
+  const startTime = performance.now();
+
+  // Extract text from both files in parallel
+  const [lines1, lines2] = await Promise.all([
+    extractText(file1, opts),
+    extractText(file2, opts),
+  ]);
+
+  // Compute diff
+  const diffLines = computeLCS(lines1, lines2, opts);
+  const stats = computeStats(diffLines);
+  const duration = Math.round(performance.now() - startTime);
+
+  return {
+    file1: {
+      name: file1.name,
+      size: file1.size,
+      type: detectFormat(file1),
+      lineCount: lines1.length,
+      extractedAt: Date.now(),
+    },
+    file2: {
+      name: file2.name,
+      size: file2.size,
+      type: detectFormat(file2),
+      lineCount: lines2.length,
+      extractedAt: Date.now(),
+    },
+    diffLines,
+    stats,
+    similarity: stats.similarityPercentage,
+    duration,
+  };
+}
+
+// ─── Export Utilities ─────────────────────────────────────────────────────────
+
+export function exportAsUnifiedDiff(result: ComparisonResult): string {
+  const lines: string[] = [
+    `--- ${result.file1.name}`,
+    `+++ ${result.file2.name}`,
+    `@@ Similarity: ${result.similarity}% | Same: ${result.stats.sameLines} | Added: ${result.stats.addedLines} | Removed: ${result.stats.removedLines} | Modified: ${result.stats.modifiedLines} @@`,
+    '',
+  ];
+
+  for (const diff of result.diffLines) {
+    switch (diff.type) {
+      case 'same':
+        lines.push(`  ${diff.content}`);
+        break;
+      case 'added':
+        lines.push(`+ ${diff.content}`);
+        break;
+      case 'removed':
+        lines.push(`- ${diff.content}`);
+        break;
+      case 'modified':
+        lines.push(`- ${diff.oldContent}`);
+        lines.push(`+ ${diff.content}`);
+        break;
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function exportAsHTML(result: ComparisonResult): string {
+  const escapeHtml = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  const rows = result.diffLines.map(diff => {
+    const cls = diff.type;
+    switch (diff.type) {
+      case 'same':
+        return `<tr class="${cls}"><td class="ln">${diff.lineNumber1}</td><td>${escapeHtml(diff.content)}</td><td class="ln">${diff.lineNumber2}</td><td>${escapeHtml(diff.content)}</td></tr>`;
+      case 'removed':
+        return `<tr class="${cls}"><td class="ln">${diff.lineNumber1}</td><td>${escapeHtml(diff.content)}</td><td class="ln"></td><td></td></tr>`;
+      case 'added':
+        return `<tr class="${cls}"><td class="ln"></td><td></td><td class="ln">${diff.lineNumber2}</td><td>${escapeHtml(diff.content)}</td></tr>`;
+      case 'modified':
+        return `<tr class="${cls}"><td class="ln">${diff.lineNumber1}</td><td>${escapeHtml(diff.oldContent || '')}</td><td class="ln">${diff.lineNumber2}</td><td>${escapeHtml(diff.content)}</td></tr>`;
+    }
+  }).join('\n');
+
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>File Comparison: ${escapeHtml(result.file1.name)} vs ${escapeHtml(result.file2.name)}</title>
+<style>
+  body{font-family:monospace;margin:20px;background:#1e1e2e;color:#cdd6f4}
+  h2{color:#89b4fa}
+  table{width:100%;border-collapse:collapse}
+  td{padding:2px 8px;border:1px solid #313244;white-space:pre-wrap;word-break:break-all}
+  .ln{width:40px;text-align:right;color:#6c7086;user-select:none}
+  .same td{background:#1e1e2e}
+  .added td:nth-child(3),.added td:nth-child(4){background:#1e3a2a}
+  .removed td:nth-child(1),.removed td:nth-child(2){background:#3a1e1e}
+  .modified td:nth-child(1),.modified td:nth-child(2){background:#3a351e}
+  .modified td:nth-child(3),.modified td:nth-child(4){background:#1e3a35}
+  .stats{display:flex;gap:16px;margin:12px 0;flex-wrap:wrap}
+  .stat{padding:6px 12px;border-radius:6px;font-size:14px}
+  .stat-same{background:#1e3a2a;color:#a6e3a1}
+  .stat-added{background:#1e3a2a;color:#94e2d5}
+  .stat-removed{background:#3a1e1e;color:#f38ba8}
+  .stat-modified{background:#3a351e;color:#f9e2af}
+</style></head><body>
+<h2>File Comparison</h2>
+<p><strong>${escapeHtml(result.file1.name)}</strong> vs <strong>${escapeHtml(result.file2.name)}</strong></p>
+<div class="stats">
+  <span class="stat stat-same">Similarity: ${result.similarity}%</span>
+  <span class="stat stat-same">Same: ${result.stats.sameLines}</span>
+  <span class="stat stat-added">Added: ${result.stats.addedLines}</span>
+  <span class="stat stat-removed">Removed: ${result.stats.removedLines}</span>
+  <span class="stat stat-modified">Modified: ${result.stats.modifiedLines}</span>
+</div>
+<table>
+<thead><tr><th class="ln">#</th><th>${escapeHtml(result.file1.name)}</th><th class="ln">#</th><th>${escapeHtml(result.file2.name)}</th></tr></thead>
+<tbody>${rows}</tbody>
+</table></body></html>`;
+}
+
+export function exportAsJSON(result: ComparisonResult): string {
+  return JSON.stringify(result, null, 2);
+}

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -251,6 +251,40 @@ function isPdfTextItem(item: unknown): item is { str: string } {
   return typeof item === 'object' && item !== null && 'str' in item && typeof item.str === 'string';
 }
 
+interface PdfTextContentChunk {
+  items?: unknown[];
+}
+
+interface PdfPageProxyLike {
+  streamTextContent?: (params?: { includeMarkedContent?: boolean; disableNormalization?: boolean }) => ReadableStream<PdfTextContentChunk>;
+  getTextContent?: () => Promise<{ items?: unknown[] }>;
+}
+
+async function readPdfTextItems(page: PdfPageProxyLike): Promise<unknown[]> {
+  if (typeof page.streamTextContent === 'function') {
+    const reader = page.streamTextContent().getReader();
+    const items: unknown[] = [];
+
+    try {
+      let chunk = await reader.read();
+      while (!chunk.done) {
+        const { value } = chunk;
+        if (value?.items) {
+          items.push(...value.items);
+        }
+        chunk = await reader.read();
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return items;
+  }
+
+  const textContent = await page.getTextContent?.();
+  return textContent?.items ?? [];
+}
+
 export function ensurePdfJsRuntimeCompatibility(): void {
   if (typeof Promise.withResolvers !== 'function') {
     Object.defineProperty(Promise, 'withResolvers', {
@@ -350,8 +384,8 @@ export async function extractTextFromPDF(file: File): Promise<string[]> {
 
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
-      const textContent = await page.getTextContent();
-      const pageText = textContent.items
+      const textItems = await readPdfTextItems(page);
+      const pageText = textItems
         .map((item: unknown) => (isPdfTextItem(item) ? item.str : ''))
         .join('');
       const pageLines = pageText.split('\n').filter((l: string) => l.trim() !== '');

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -297,8 +297,7 @@ export async function extractTextFromPDF(file: File): Promise<string[]> {
 
     const arrayBuffer = await readFileAsArrayBuffer(file);
     const pdfData = new Uint8Array(arrayBuffer);
-    const documentParams = { data: pdfData, disableWorker: true };
-    const pdf = await pdfjsLib.getDocument(documentParams).promise;
+    const pdf = await pdfjsLib.getDocument({ data: pdfData }).promise;
     const lines: string[] = [];
 
     for (let i = 1; i <= pdf.numPages; i++) {

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -230,9 +230,9 @@ function isPdfTextItem(item: unknown): item is { str: string } {
 
 export async function extractTextFromPDF(file: File): Promise<string[]> {
   try {
-    const pdfjsLib = await import('pdfjs-dist');
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
     pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
-      'pdfjs-dist/build/pdf.worker.min.mjs',
+      'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
       import.meta.url
     ).href;
 

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -12,6 +12,10 @@ interface PdfPromiseWithResolvers<T> {
 declare global {
   interface PromiseConstructor {
     withResolvers?<T>(): PdfPromiseWithResolvers<T>;
+    try?<T, Args extends unknown[]>(
+      callback: (...args: Args) => T | PromiseLike<T>,
+      ...args: Args
+    ): Promise<T>;
   }
 
   interface Response {
@@ -274,6 +278,48 @@ export function ensurePdfJsRuntimeCompatibility(): void {
     });
   }
 
+  if (typeof Promise.try !== 'function') {
+    Object.defineProperty(Promise, 'try', {
+      configurable: true,
+      writable: true,
+      value: <T, Args extends unknown[]>(
+        callback: (...args: Args) => T | PromiseLike<T>,
+        ...args: Args
+      ): Promise<T> => new Promise<T>((resolve) => {
+        resolve(callback(...args));
+      }),
+    });
+  }
+
+  if (typeof Array.prototype.at !== 'function') {
+    Object.defineProperty(Array.prototype, 'at', {
+      configurable: true,
+      writable: true,
+      value: function at<T>(this: ArrayLike<T>, index: number): T | undefined {
+        const length = this.length >>> 0;
+        const relativeIndex = Math.trunc(index) || 0;
+        const actualIndex = relativeIndex >= 0 ? relativeIndex : length + relativeIndex;
+        return actualIndex >= 0 && actualIndex < length ? this[actualIndex] : undefined;
+      },
+    });
+  }
+
+  const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype) as {
+    at?: (index: number) => unknown;
+  };
+  if (typedArrayPrototype && typeof typedArrayPrototype.at !== 'function') {
+    Object.defineProperty(typedArrayPrototype, 'at', {
+      configurable: true,
+      writable: true,
+      value: function at(this: ArrayLike<unknown>, index: number): unknown {
+        const length = this.length >>> 0;
+        const relativeIndex = Math.trunc(index) || 0;
+        const actualIndex = relativeIndex >= 0 ? relativeIndex : length + relativeIndex;
+        return actualIndex >= 0 && actualIndex < length ? this[actualIndex] : undefined;
+      },
+    });
+  }
+
   if (typeof Response !== 'undefined' && typeof Response.prototype.bytes !== 'function') {
     Object.defineProperty(Response.prototype, 'bytes', {
       configurable: true,
@@ -294,6 +340,8 @@ export async function extractTextFromPDF(file: File): Promise<string[]> {
       'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
       import.meta.url
     ).href;
+
+    await import('pdfjs-dist/legacy/build/pdf.worker.mjs');
 
     const arrayBuffer = await readFileAsArrayBuffer(file);
     const pdfData = new Uint8Array(arrayBuffer);

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -1,5 +1,24 @@
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
+type PromiseResolver<T> = (value: T | PromiseLike<T>) => void;
+type PromiseRejecter = (reason?: unknown) => void;
+
+interface PdfPromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: PromiseResolver<T>;
+  reject: PromiseRejecter;
+}
+
+declare global {
+  interface PromiseConstructor {
+    withResolvers?<T>(): PdfPromiseWithResolvers<T>;
+  }
+
+  interface Response {
+    bytes?(): Promise<Uint8Array>;
+  }
+}
+
 export interface ComparisonOptions {
   ignoreWhitespace: boolean;
   ignoreCase: boolean;
@@ -228,8 +247,48 @@ function isPdfTextItem(item: unknown): item is { str: string } {
   return typeof item === 'object' && item !== null && 'str' in item && typeof item.str === 'string';
 }
 
+export function ensurePdfJsRuntimeCompatibility(): void {
+  if (typeof Promise.withResolvers !== 'function') {
+    Object.defineProperty(Promise, 'withResolvers', {
+      configurable: true,
+      writable: true,
+      value: <T>(): PdfPromiseWithResolvers<T> => {
+        let resolvePromise: PromiseResolver<T> | undefined;
+        let rejectPromise: PromiseRejecter | undefined;
+
+        const promise = new Promise<T>((resolve, reject) => {
+          resolvePromise = resolve;
+          rejectPromise = reject;
+        });
+
+        if (!resolvePromise || !rejectPromise) {
+          throw new Error('Unable to create Promise capability');
+        }
+
+        return {
+          promise,
+          resolve: resolvePromise,
+          reject: rejectPromise,
+        };
+      },
+    });
+  }
+
+  if (typeof Response !== 'undefined' && typeof Response.prototype.bytes !== 'function') {
+    Object.defineProperty(Response.prototype, 'bytes', {
+      configurable: true,
+      writable: true,
+      value: async function bytes(this: Response): Promise<Uint8Array> {
+        return new Uint8Array(await this.arrayBuffer());
+      },
+    });
+  }
+}
+
 export async function extractTextFromPDF(file: File): Promise<string[]> {
   try {
+    ensurePdfJsRuntimeCompatibility();
+
     const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
     pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
       'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
@@ -238,7 +297,8 @@ export async function extractTextFromPDF(file: File): Promise<string[]> {
 
     const arrayBuffer = await readFileAsArrayBuffer(file);
     const pdfData = new Uint8Array(arrayBuffer);
-    const pdf = await pdfjsLib.getDocument({ data: pdfData }).promise;
+    const documentParams = { data: pdfData, disableWorker: true };
+    const pdf = await pdfjsLib.getDocument(documentParams).promise;
     const lines: string[] = [];
 
     for (let i = 1; i <= pdf.numPages; i++) {

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -224,6 +224,10 @@ function parseCSVRows(text: string): string[][] {
   return rows;
 }
 
+function isPdfTextItem(item: unknown): item is { str: string } {
+  return typeof item === 'object' && item !== null && 'str' in item && typeof item.str === 'string';
+}
+
 export async function extractTextFromPDF(file: File): Promise<string[]> {
   try {
     const pdfjsLib = await import('pdfjs-dist');
@@ -239,9 +243,8 @@ export async function extractTextFromPDF(file: File): Promise<string[]> {
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
       const textContent = await page.getTextContent();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pageText = textContent.items
-        .map((item: any) => (item && typeof item.str === 'string' ? item.str : ''))
+        .map((item: unknown) => (isPdfTextItem(item) ? item.str : ''))
         .join('');
       const pageLines = pageText.split('\n').filter((l: string) => l.trim() !== '');
       if (pageLines.length > 0) {

--- a/src/utils/fileComparator.ts
+++ b/src/utils/fileComparator.ts
@@ -237,7 +237,8 @@ export async function extractTextFromPDF(file: File): Promise<string[]> {
     ).href;
 
     const arrayBuffer = await readFileAsArrayBuffer(file);
-    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    const pdfData = new Uint8Array(arrayBuffer);
+    const pdf = await pdfjsLib.getDocument({ data: pdfData }).promise;
     const lines: string[] = [];
 
     for (let i = 1; i <= pdf.numPages; i++) {

--- a/src/utils/sharedTools.ts
+++ b/src/utils/sharedTools.ts
@@ -1117,3 +1117,182 @@ export function parseJsonPrompt(json: string): ParseJsonPromptResult {
     template: { model, temperature, maxTokens, messages },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Text Comparison (platform-agnostic — no browser / Node-specific APIs)
+// ---------------------------------------------------------------------------
+
+export interface TextComparisonOptions {
+  ignoreWhitespace?: boolean;
+  ignoreCase?: boolean;
+  ignoreBlankLines?: boolean;
+  similarityThreshold?: number;
+}
+
+export interface TextDiffLine {
+  type: 'same' | 'added' | 'removed' | 'modified';
+  lineNumber1?: number;
+  lineNumber2?: number;
+  content: string;
+  oldContent?: string;
+  similarity?: number;
+}
+
+export interface TextComparisonStats {
+  totalLines: number;
+  sameLines: number;
+  addedLines: number;
+  removedLines: number;
+  modifiedLines: number;
+  similarityPercentage: number;
+}
+
+export interface TextComparisonResult {
+  diffLines: TextDiffLine[];
+  stats: TextComparisonStats;
+  similarity: number;
+}
+
+/**
+ * Compute the Levenshtein edit distance between two strings.
+ */
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr = new Array<number>(n + 1);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n];
+}
+
+function lineSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen === 0) return 1;
+  return 1 - levenshtein(a, b) / maxLen;
+}
+
+/**
+ * Compare two text strings line-by-line and return a structured diff.
+ *
+ * This is the platform-agnostic core used by the CLI `compare` command,
+ * the REST API `/api/analysers/compare` endpoint, and the MCP server.
+ */
+export function compareTexts(
+  text1: string,
+  text2: string,
+  options: TextComparisonOptions = {},
+): TextComparisonResult {
+  const {
+    ignoreWhitespace = false,
+    ignoreCase = false,
+    ignoreBlankLines = false,
+    similarityThreshold = 0.6,
+  } = options;
+
+  const normalize = (s: string): string => {
+    let r = s;
+    if (ignoreWhitespace) r = r.replace(/\s+/g, ' ').trim();
+    if (ignoreCase) r = r.toLowerCase();
+    return r;
+  };
+
+  let linesA = text1.split('\n');
+  let linesB = text2.split('\n');
+
+  if (ignoreBlankLines) {
+    linesA = linesA.filter(l => l.trim() !== '');
+    linesB = linesB.filter(l => l.trim() !== '');
+  }
+
+  const m = linesA.length;
+  const n = linesB.length;
+
+  // LCS table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (normalize(linesA[i - 1]) === normalize(linesB[j - 1])) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Backtrack
+  const rawDiff: Array<{ type: 'same' | 'removed' | 'added'; iA: number; iB: number }> = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && normalize(linesA[i - 1]) === normalize(linesB[j - 1])) {
+      rawDiff.unshift({ type: 'same', iA: i - 1, iB: j - 1 });
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      rawDiff.unshift({ type: 'added', iA: -1, iB: j - 1 });
+      j--;
+    } else {
+      rawDiff.unshift({ type: 'removed', iA: i - 1, iB: -1 });
+      i--;
+    }
+  }
+
+  // Post-process: merge adjacent removed+added into 'modified' when similar
+  const diffLines: TextDiffLine[] = [];
+  let idx = 0;
+  while (idx < rawDiff.length) {
+    const e = rawDiff[idx];
+    if (e.type === 'removed' && idx + 1 < rawDiff.length && rawDiff[idx + 1].type === 'added') {
+      const oldLine = linesA[e.iA];
+      const newLine = linesB[rawDiff[idx + 1].iB];
+      const sim = lineSimilarity(normalize(oldLine), normalize(newLine));
+      if (sim >= similarityThreshold) {
+        diffLines.push({
+          type: 'modified',
+          lineNumber1: e.iA + 1,
+          lineNumber2: rawDiff[idx + 1].iB + 1,
+          content: newLine,
+          oldContent: oldLine,
+          similarity: Math.round(sim * 100),
+        });
+        idx += 2;
+        continue;
+      }
+    }
+    if (e.type === 'same') {
+      diffLines.push({ type: 'same', lineNumber1: e.iA + 1, lineNumber2: e.iB + 1, content: linesA[e.iA] });
+    } else if (e.type === 'removed') {
+      diffLines.push({ type: 'removed', lineNumber1: e.iA + 1, content: linesA[e.iA] });
+    } else {
+      diffLines.push({ type: 'added', lineNumber2: e.iB + 1, content: linesB[e.iB] });
+    }
+    idx++;
+  }
+
+  // Stats
+  const sameLines = diffLines.filter(d => d.type === 'same').length;
+  const addedLines = diffLines.filter(d => d.type === 'added').length;
+  const removedLines = diffLines.filter(d => d.type === 'removed').length;
+  const modifiedEntries = diffLines.filter(d => d.type === 'modified');
+  const modifiedLines = modifiedEntries.length;
+  const totalLines = diffLines.length;
+  const modSimSum = modifiedEntries.reduce((s, d) => s + (d.similarity || 0) / 100, 0);
+  const effectiveSame = sameLines + modSimSum;
+  const similarityPercentage = totalLines > 0
+    ? Math.min(100, Math.max(0, Math.round((effectiveSame / totalLines) * 100)))
+    : (text1 === text2 ? 100 : 0);
+
+  return {
+    diffLines,
+    stats: { totalLines, sameLines, addedLines, removedLines, modifiedLines, similarityPercentage },
+    similarity: similarityPercentage,
+  };
+}

--- a/src/utils/sharedToolsNode.ts
+++ b/src/utils/sharedToolsNode.ts
@@ -49,6 +49,11 @@ export type {
   BuildJsonPromptResult,
   ParseJsonPromptResult,
   ValidatePromptResult,
+  // Text Comparison
+  TextComparisonOptions,
+  TextDiffLine,
+  TextComparisonStats,
+  TextComparisonResult,
 } from './sharedTools.js';
 
 export {
@@ -77,6 +82,8 @@ export {
   validatePromptTemplate,
   buildJsonPrompt,
   parseJsonPrompt,
+  // Text Comparison
+  compareTexts,
 } from './sharedTools.js';
 
 // ---------------------------------------------------------------------------

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="vite/client" />
 declare const __COMMIT_HASH__: string;
 
+declare module 'pdfjs-dist/legacy/build/pdf.worker.mjs' {
+  export const WorkerMessageHandler: unknown;
+}
+
 // Web Speech API types (not present in all TypeScript DOM lib versions)
 interface SpeechRecognitionResult {
   readonly isFinal: boolean;


### PR DESCRIPTION
- Core engine: LCS diff algorithm, Levenshtein similarity scoring
- Supports PDF, DOCX, XLSX, CSV, JSON, TXT, Markdown, HTML, XML
- React UI: side-by-side & unified views, drag-and-drop, export (.diff/.html/.json)
- Fullscreen modal with zoom in/out for detailed inspection
- CLI: 'qautils compare <file1> <file2>' with flags (-w, -i, -b, -t, -f)
- Interactive TUI: File Comparator under Analysers section
- API: POST /api/analysers/compare with full OpenAPI/Swagger docs
- Shared compareTexts() in sharedTools.ts (platform-agnostic)
- Tests: 10 CLI tests, 4 API tests, comprehensive unit tests
- Documentation: testing-tools.md with CLI/API usage examples
- Implementation plan: docs/plans/file-comparator.md